### PR TITLE
Update composer.json for PHP 8.2 and Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "license": "MIT",
     "type": "project",
     "require": {
-        "php": ">=5.6.4",
-        "laravel/framework": "5.3.*"
+        "php": "^8.2",
+        "laravel/framework": "^11.0"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",
@@ -45,6 +45,9 @@
         ]
     },
     "config": {
-        "preferred-install": "dist"
+        "preferred-install": "dist",
+        "allow-plugins": {
+            "kylekatarnls/update-helper": true
+        }
     }
 }


### PR DESCRIPTION
## Summary
- bump PHP requirement to ^8.2 and Laravel to ^11.0
- allow the update-helper plugin in Composer config

## Testing
- `composer validate --no-check-all`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6873218c31fc832e97c20ed33d659037