### PR TITLE
Add dashboard and login links

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class DashboardController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('auth');
+    }
+
+    public function index()
+    {
+        return view('dashboard');
+    }
+}

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Dashboard</title>
+</head>
+<body>
+    <h1>Ressapp Dashboard</h1>
+    <p>Welcome, {{ Auth::user()->name }}!</p>
+    <p>This is your dashboard. Use the navigation to explore the app features.</p>
+</body>
+</html>

--- a/resources/views/index.php
+++ b/resources/views/index.php
@@ -138,9 +138,14 @@
                         <span>Lorem Ipsum</span>
                     </div>
                     <div id="sub_crumb">
-                        <span>You are not logged in.</span>
-                        <a href="{{ url('/login') }}">Log in</a>
-                        / <a href="{{ url('/register') }}">Register</a>
+                        @auth
+                            <span>Welcome, {{ Auth::user()->name }}.</span>
+                            <a href="{{ url('/dashboard') }}">Dashboard</a>
+                        @else
+                            <span>You are not logged in.</span>
+                            <a href="{{ url('/login') }}">Log in</a>
+                            / <a href="{{ url('/register') }}">Register</a>
+                        @endauth
                     </div>
                 </div>
             </header>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Auth;
+use App\Http\Controllers\DashboardController;
 
 Route::get('/', function () {
     return view('index');
@@ -9,3 +10,4 @@ Route::get('/', function () {
 Auth::routes();
 
 Route::get('/home', 'HomeController@index')->name('home');
+Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');

--- a/tests/DashboardTest.php
+++ b/tests/DashboardTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\User;
+use Illuminate\Support\Facades\Hash;
+
+class DashboardTest extends TestCase
+{
+    public function testLoginPageLoads()
+    {
+        $response = $this->get('/login');
+        $response->assertStatus(200);
+    }
+
+    public function testDashboardRequiresAuthentication()
+    {
+        $response = $this->get('/dashboard');
+        $response->assertRedirect('/login');
+    }
+
+    public function testAuthenticatedUserCanSeeDashboard()
+    {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'password' => Hash::make('password'),
+        ]);
+
+        $response = $this->actingAs($user)->get('/dashboard');
+        $response->assertStatus(200);
+        $response->assertSee('Ressapp Dashboard');
+    }
+}


### PR DESCRIPTION
## Summary
- add `DashboardController` guarded by auth middleware
- create simple dashboard Blade view
- show dashboard link when user is logged in
- register dashboard route
- add tests for login and dashboard access

## Testing
- `./vendor/bin/phpunit` *(fails: Call to undefined function each())*

------
https://chatgpt.com/codex/tasks/task_e_687838b79768832ea1ba0408010a1567