### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+      - name: Run PHPUnit
+        run: ./vendor/bin/phpunit --testdox

--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ Tests are written with PHPUnit. After installing dependencies with Composer run 
 
 If you have PHPUnit installed globally you can simply run `phpunit` instead.
 
+
+### Continuous Integration
+
+A GitHub Actions workflow runs the PHPUnit suite on every push and pull request. The workflow is defined in `.github/workflows/ci.yml`.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run PHPUnit
- mention the CI workflow in the README

## Testing
- `./vendor/bin/phpunit --testdox` *(fails: cannot find symfony/deprecation-contracts)*

------
https://chatgpt.com/codex/tasks/task_e_68841c80a56c832ead6110feebd62fb8