### PR TITLE
Add deployment instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+      - name: Run PHPUnit
+        run: ./vendor/bin/phpunit --testdox

--- a/README.md
+++ b/README.md
@@ -28,3 +28,23 @@ Tests are written with PHPUnit. After installing dependencies with Composer run 
 
 If you have PHPUnit installed globally you can simply run `phpunit` instead.
 
+
+### Continuous Integration
+
+A GitHub Actions workflow runs the PHPUnit suite on every push and pull request. The workflow is defined in `.github/workflows/ci.yml`.
+
+## Deploying to Hostinger
+
+1. Push your local code to a remote Git provider such as GitHub.
+2. In Hostinger's **Git** interface choose **Add repository** and clone the repo into your account.
+3. Set your domain (e.g. `darkorange-chinchilla-918430.hostingersite.com`) to use the project's `public` directory as its document root.
+4. Enable SSH access and run the helper script from the project root:
+
+   ```bash
+   ./hostinger-setup.sh
+   ```
+
+   The script installs Composer dependencies, copies `.env.example` if needed,
+   runs database migrations and adjusts directory permissions.
+
+After configuration the site will be accessible at your Hostinger domain.

--- a/hostinger-setup.sh
+++ b/hostinger-setup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# Install PHP dependencies without development packages
+composer install --no-dev --optimize-autoloader
+
+# Copy .env.example if .env is missing
+if [ ! -f .env ]; then
+  cp .env.example .env
+fi
+
+# Run database migrations
+php artisan migrate --force
+
+# Set writable permissions for storage and cache directories
+chmod -R 775 storage bootstrap/cache
+
+echo "Hostinger deployment complete."


### PR DESCRIPTION
## Summary
- document how to deploy the Laravel app to Hostinger
- add `hostinger-setup.sh` helper script for the install steps

## Testing
- `./vendor/bin/phpunit --testdox` *(fails: Failed opening required symfony/deprecation-contracts)*

------
https://chatgpt.com/codex/tasks/task_e_68841c80a56c832ead6110feebd62fb8