### PR TITLE
Add basic role and permission scaffolding

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,10 +5,11 @@ namespace App\Models;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable
 {
-    use Notifiable, HasFactory;
+    use Notifiable, HasFactory, HasRoles;
 
     /**
      * The attributes that are mass assignable.

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "laravel/ui": "^4.6",
         "stancl/tenancy": "^3.9",
         "stripe/stripe-php": "^17.4",
-        "laravel/tinker": "^2.10"
+        "laravel/tinker": "^2.10",
+        "spatie/laravel-permission": "^6.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.21",

--- a/database/migrations/2024_01_01_000000_create_permission_tables.php
+++ b/database/migrations/2024_01_01_000000_create_permission_tables.php
@@ -1,0 +1,74 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('permissions', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->string('guard_name');
+            $table->timestamps();
+        });
+
+        Schema::create('roles', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->string('guard_name');
+            $table->timestamps();
+        });
+
+        Schema::create('model_has_permissions', function (Blueprint $table) {
+            $table->unsignedBigInteger('permission_id');
+            $table->morphs('model');
+
+            $table->foreign('permission_id')
+                ->references('id')
+                ->on('permissions')
+                ->onDelete('cascade');
+
+            $table->primary(['permission_id', 'model_id', 'model_type'], 'model_has_permissions_permission_model_type_primary');
+        });
+
+        Schema::create('model_has_roles', function (Blueprint $table) {
+            $table->unsignedBigInteger('role_id');
+            $table->morphs('model');
+
+            $table->foreign('role_id')
+                ->references('id')
+                ->on('roles')
+                ->onDelete('cascade');
+
+            $table->primary(['role_id', 'model_id', 'model_type'], 'model_has_roles_role_model_type_primary');
+        });
+
+        Schema::create('role_has_permissions', function (Blueprint $table) {
+            $table->unsignedBigInteger('permission_id');
+            $table->unsignedBigInteger('role_id');
+
+            $table->foreign('permission_id')
+                ->references('id')
+                ->on('permissions')
+                ->onDelete('cascade');
+
+            $table->foreign('role_id')
+                ->references('id')
+                ->on('roles')
+                ->onDelete('cascade');
+
+            $table->primary(['permission_id', 'role_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('role_has_permissions');
+        Schema::dropIfExists('model_has_roles');
+        Schema::dropIfExists('model_has_permissions');
+        Schema::dropIfExists('roles');
+        Schema::dropIfExists('permissions');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -9,6 +9,7 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $this->call([
+            RolesSeeder::class,
             AdminUserSeeder::class,
             ContactTagGroupSeeder::class,
             DemoDataSeeder::class, // Add demo data seeder

--- a/database/seeders/RolesSeeder.php
+++ b/database/seeders/RolesSeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\Models\Permission;
+
+class RolesSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $roles = ['Admin', 'Landlord', 'Agent', 'Tenant'];
+
+        foreach ($roles as $role) {
+            Role::firstOrCreate(['name' => $role]);
+        }
+
+        $viewTenants = Permission::firstOrCreate(['name' => 'view tenants']);
+
+        foreach (['Admin', 'Landlord'] as $role) {
+            Role::findByName($role)->givePermissionTo($viewTenants);
+        }
+    }
+}

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -15,9 +15,11 @@
                     <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                         {{ __('Dashboard') }}
                     </x-nav-link>
-                    <x-nav-link :href="route('tenants.index')" :active="request()->routeIs('tenants.*')">
-                        {{ __('Tenants') }}
-                    </x-nav-link>
+                    @can('view tenants')
+                        <x-nav-link :href="route('tenants.index')" :active="request()->routeIs('tenants.*')">
+                            {{ __('Tenants') }}
+                        </x-nav-link>
+                    @endcan
                     <!-- Removed all property, contact, diary, accounts links for landlord app -->
                 </div>
             </div>
@@ -74,9 +76,11 @@
             <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                 {{ __('Dashboard') }}
             </x-responsive-nav-link>
-            <x-responsive-nav-link :href="route('tenants.index')" :active="request()->routeIs('tenants.*')">
-                {{ __('Tenants') }}
-            </x-responsive-nav-link>
+            @can('view tenants')
+                <x-responsive-nav-link :href="route('tenants.index')" :active="request()->routeIs('tenants.*')">
+                    {{ __('Tenants') }}
+                </x-responsive-nav-link>
+            @endcan
         </div>
 
         <!-- Responsive Settings Options -->

--- a/routes/tenant.php
+++ b/routes/tenant.php
@@ -22,6 +22,7 @@ Route::middleware([
     'web',
     InitializeTenancyByDomain::class,
     PreventAccessFromCentralDomains::class,
+    'role:Tenant'
 ])->group(function () {
     Route::get('/', function () {
         return 'This is your multi-tenant application. The id of the current tenant is ' . tenant('id');

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,7 +21,7 @@ Route::middleware('auth')->group(function () {
 });
 
 // Central dashboard routes (should NOT use tenancy middleware)
-Route::middleware(['auth', 'verified'])->group(function () {
+Route::middleware(['auth', 'verified', 'role:Admin|Landlord'])->group(function () {
     // Remove duplicate dashboard route
     Route::post('/dashboard', [DashboardController::class, 'create'])->name('dashboard.create');
     Route::delete('/dashboard/{id}', [DashboardController::class, 'destroy'])->name('dashboard.destroy');
@@ -40,7 +40,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
 });
 
 // Tenant routes (aktonz.ressapp.com, etc.)
-Route::middleware(['auth', 'tenancy'])->group(function () {
+Route::middleware(['auth', 'tenancy', 'role:Tenant'])->group(function () {
     Route::resource('properties', PropertyController::class);
     Route::resource('contacts', ContactController::class);
     Route::resource('diary', DiaryController::class);


### PR DESCRIPTION
## Summary
- require spatie/laravel-permission package
- seed default roles and view-tenants permission
- guard routes and navigation with role/permission checks
- include migration tables for roles and permissions

## Testing
- `php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider" --tag="migrations" --tag="config"` *(fails: symfony/deprecation-contracts not found)*
- `vendor/bin/phpunit` *(fails: symfony/deprecation-contracts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68953ea4edc0832ebca55a0a248bd813