### PR TITLE
docs: add competitor research for UK estate & letting agent software

### DIFF
--- a/docs/competitors.md
+++ b/docs/competitors.md
@@ -1,0 +1,66 @@
+# UK Estate & Letting Agent Software Competitors
+
+This document lists major UK competitors for Ressapp in the estate and letting agent software space. Each entry includes the company's website and a brief description of their offering.
+
+1. **Reapit**  
+   Website: https://www.reapit.com/  
+   Company: Reapit Ltd, London, UK.  
+   Overview: Cloud-based CRM and property management platform serving estate and letting agents with sales, lettings, and client accounting.
+
+2. **Alto**  
+   Website: https://www.altosoftware.co.uk/  
+   Company: Houseful (formerly Zoopla), London, UK.  
+   Overview: End-to-end software for sales and lettings with portal publishing, marketing tools, and client management.
+
+3. **Dezrez (Rezi)**  
+   Website: https://www.dezrez.co.uk/  
+   Company: Dezrez Services Ltd, Swansea, UK.  
+   Overview: Web-based CRM and property management solution offering integrations, automation, and website services.
+
+4. **AgentOS**  
+   Website: https://www.agentos.co.uk/  
+   Company: Agent Software Services Ltd (formerly LetMC), Cardiff, UK.  
+   Overview: Cloud platform for sales and lettings featuring diary management, accounting, and extensive partner integrations.
+
+5. **Gnomen**  
+   Website: https://www.gnomen.co.uk/  
+   Company: Gnomen Ltd, London, UK.  
+   Overview: Web-based software with built-in CMS, property management, and marketing tools for agents.
+
+6. **Street.co.uk**  
+   Website: https://street.co.uk/  
+   Company: Street Systems Ltd, Manchester, UK.  
+   Overview: Modern CRM platform focusing on automation, vendor and buyer apps, and digital onboarding.
+
+7. **PCHomes**  
+   Website: https://www.pchomes.co.uk/  
+   Company: Property Computer Systems Ltd, Bracknell, UK.  
+   Overview: Multi-branch software covering residential sales, lettings, management, and accounts.
+
+8. **Acquaint CRM**  
+   Website: https://www.acquaintcrm.co.uk/  
+   Company: Beehive Systems Ltd, Milton Keynes, UK.  
+   Overview: CRM for estate and letting agents with property marketing, diary, and client management features.
+
+9. **AgentPro**  
+   Website: https://www.agentpro.co.uk/  
+   Company: Resource Techniques Ltd, Barnet, UK.  
+   Overview: Desktop and cloud-based software providing sales, lettings, and property management functionality.
+
+10. **Veco by Eurolink**  
+   Website: https://www.eurolink.co/  
+   Company: Eurolink Technology Ltd, London, UK.  
+   Overview: Comprehensive CRM platform with workflow automation, accounts, and API integrations.
+
+## Improvement Opportunities for Ressapp
+
+- **Unified CRM & Accounting**: Offer seamless sales, lettings, and client accounting similar to Reapit and PCHomes.
+- **Portal & Website Integrations**: Ensure one-click listing to portals like Rightmove, Zoopla, and OnTheMarket.
+- **Automation & Workflows**: Provide customizable workflow automation akin to Street and Rezi for repetitive tasks.
+- **Partner Ecosystem / API**: Open RESTful APIs to integrate with third-party services as AgentOS does.
+- **Mobile & Client Apps**: Develop mobile apps and self-service portals for vendors, landlords, and tenants.
+- **Analytics & Dashboards**: Include real-time KPIs and reporting to give agencies actionable insights.
+- **Scalability & Multi-Branch Support**: Support growth for agencies with multiple branches or franchises.
+
+Implementing these features thoughtfully will position Ressapp as a competitive choice among UK estate and letting agent software solutions.
+


### PR DESCRIPTION
## Summary
- document key UK estate and letting agent software competitors and feature recommendations for Ressapp

## Testing
- `npm run build`
- `./vendor/bin/phpunit` *(fails: requires symfony/deprecation-contracts)*
- `composer install` *(fails: 403 downloading brick/math)*

------
https://chatgpt.com/codex/tasks/task_e_689540128b84832e85f4dbff626a3a91