### PR TITLE
Add Codex environment setup script

### DIFF
--- a/setup_codex_env.sh
+++ b/setup_codex_env.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install Codex CLI if not already installed
+if ! command -v codex-cli >/dev/null 2>&1; then
+  npm install -g @openai/codex-cli
+fi
+
+# Set environment variables (replace placeholder values)
+export OPENAI_API_KEY="your-openai-api-key"
+export OTHER_REQUIRED_KEY="your-other-key"
+
+# Optionally persist variables for future shells
+cat <<'EOV' >> ~/.bashrc
+export OPENAI_API_KEY="your-openai-api-key"
+export OTHER_REQUIRED_KEY="your-other-key"
+EOV
+
+echo "Codex environment setup complete. Remember to replace placeholders with actual keys."


### PR DESCRIPTION
## Summary
- provide script to bootstrap Codex environment with codex-cli installation and placeholder API keys

## Testing
- `./vendor/bin/phpunit` *(fails: Failed opening required '/workspace/ressapp/vendor/composer/../laravel/framework/src/Illuminate/Support/functions.php')*
- `shellcheck setup_codex_env.sh` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895447e22b0832e84a38d2422c75a37