### PR TITLE
Add API resources, Sanctum auth, and webhooks

### DIFF
--- a/app/Http/Controllers/Api/AuthApiController.php
+++ b/app/Http/Controllers/Api/AuthApiController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use App\Models\User;
+
+class AuthApiController extends Controller
+{
+    public function login(Request $request)
+    {
+        $credentials = $request->validate([
+            'email' => 'required|email',
+            'password' => 'required',
+        ]);
+        $user = User::where('email', $credentials['email'])->first();
+        if (! $user || ! Hash::check($credentials['password'], $user->password)) {
+            return response()->json(['message' => 'Invalid credentials'], 401);
+        }
+        $token = $user->createToken('api-token')->plainTextToken;
+        return response()->json(['token' => $token]);
+    }
+}

--- a/app/Http/Controllers/Api/PaymentApiController.php
+++ b/app/Http/Controllers/Api/PaymentApiController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Payment;
+use App\Http\Resources\PaymentResource;
+use Illuminate\Http\Request;
+
+class PaymentApiController extends Controller
+{
+    public function index()
+    {
+        $payments = Payment::paginate(20);
+        return PaymentResource::collection($payments);
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'date' => 'required|date',
+            'invoice_id' => 'nullable|exists:invoices,id',
+            'amount' => 'required|numeric',
+            'method' => 'nullable|string',
+            'notes' => 'nullable|string',
+        ]);
+        $payment = Payment::create($validated);
+        return new PaymentResource($payment);
+    }
+
+    public function show(Payment $payment)
+    {
+        return new PaymentResource($payment);
+    }
+
+    public function update(Request $request, Payment $payment)
+    {
+        $validated = $request->validate([
+            'date' => 'sometimes|required|date',
+            'invoice_id' => 'nullable|exists:invoices,id',
+            'amount' => 'sometimes|required|numeric',
+            'method' => 'nullable|string',
+            'notes' => 'nullable|string',
+        ]);
+        $payment->update($validated);
+        return new PaymentResource($payment);
+    }
+
+    public function destroy(Payment $payment)
+    {
+        $payment->delete();
+        return response()->json(['message' => 'Deleted'], 204);
+    }
+}

--- a/app/Http/Controllers/Api/WebhookApiController.php
+++ b/app/Http/Controllers/Api/WebhookApiController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Webhook;
+use App\Http\Resources\WebhookResource;
+use Illuminate\Http\Request;
+
+class WebhookApiController extends Controller
+{
+    public function index()
+    {
+        return WebhookResource::collection(Webhook::all());
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'url' => 'required|url',
+            'event' => 'required|string',
+        ]);
+        $webhook = Webhook::create($validated);
+        return new WebhookResource($webhook);
+    }
+
+    public function destroy(Webhook $webhook)
+    {
+        $webhook->delete();
+        return response()->json(['message' => 'Deleted'], 204);
+    }
+}

--- a/app/Http/Resources/PaymentResource.php
+++ b/app/Http/Resources/PaymentResource.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PaymentResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'date' => $this->date ? $this->date->toDateString() : null,
+            'invoice_id' => $this->invoice_id,
+            'amount' => $this->amount,
+            'method' => $this->method,
+            'notes' => $this->notes,
+            'created_at' => $this->created_at ? $this->created_at->toISOString() : null,
+            'updated_at' => $this->updated_at ? $this->updated_at->toISOString() : null,
+        ];
+    }
+}

--- a/app/Http/Resources/WebhookResource.php
+++ b/app/Http/Resources/WebhookResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class WebhookResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'url' => $this->url,
+            'event' => $this->event,
+            'created_at' => $this->created_at ? $this->created_at->toISOString() : null,
+            'updated_at' => $this->updated_at ? $this->updated_at->toISOString() : null,
+        ];
+    }
+}

--- a/app/Jobs/SendWebhook.php
+++ b/app/Jobs/SendWebhook.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Http;
+
+class SendWebhook implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    protected string $url;
+    protected array $payload;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(string $url, array $payload)
+    {
+        $this->url = $url;
+        $this->payload = $payload;
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        Http::post($this->url, $this->payload);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,10 +6,11 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Spatie\Permission\Traits\HasRoles;
+use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
-    use Notifiable, HasFactory, HasRoles;
+    use HasApiTokens, Notifiable, HasFactory, HasRoles;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Models/Webhook.php
+++ b/app/Models/Webhook.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Webhook extends Model
+{
+    protected $fillable = ['url', 'event'];
+}

--- a/app/Providers/SanctumServiceProvider.php
+++ b/app/Providers/SanctumServiceProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Laravel\Sanctum\Sanctum;
+
+class SanctumServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        //
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+        Sanctum::ignoreMigrations();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "stancl/tenancy": "^3.9",
         "stripe/stripe-php": "^17.4",
         "laravel/tinker": "^2.10",
-        "spatie/laravel-permission": "^6.0"
+        "spatie/laravel-permission": "^6.0",
+        "laravel/sanctum": "^4.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.21",

--- a/config/app.php
+++ b/config/app.php
@@ -175,6 +175,7 @@ return [
         // App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
+        App\Providers\SanctumServiceProvider::class,
     ],
 
     /*

--- a/database/migrations/2025_07_21_000001_create_webhooks_table.php
+++ b/database/migrations/2025_07_21_000001_create_webhooks_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('webhooks', function (Blueprint $table) {
+            $table->id();
+            $table->string('url');
+            $table->string('event');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('webhooks');
+    }
+};

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,34 @@
+# API Documentation
+
+## Authentication
+- `POST /api/login` – obtain a token by providing `email` and `password`.
+
+Include the issued token as a Bearer token in the `Authorization` header for the requests below.
+
+## Properties
+- `GET /api/properties`
+- `POST /api/properties`
+- `GET /api/properties/{id}`
+- `PUT /api/properties/{id}`
+- `DELETE /api/properties/{id}`
+
+## Tenancies
+- `GET /api/tenancies`
+- `POST /api/tenancies`
+- `GET /api/tenancies/{id}`
+- `PUT /api/tenancies/{id}`
+- `DELETE /api/tenancies/{id}`
+
+## Payments
+- `GET /api/payments`
+- `POST /api/payments`
+- `GET /api/payments/{id}`
+- `PUT /api/payments/{id}`
+- `DELETE /api/payments/{id}`
+
+## Webhooks
+- `GET /api/webhooks`
+- `POST /api/webhooks` – subscribe with `url` and `event`.
+- `DELETE /api/webhooks/{id}`
+
+Webhooks will receive POST requests when the corresponding event occurs. Currently supported event: `property.created`.

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,26 +1,18 @@
 <?php
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\PropertyApiController;
+use App\Http\Controllers\Api\TenancyApiController;
+use App\Http\Controllers\Api\PaymentApiController;
+use App\Http\Controllers\Api\WebhookApiController;
+use App\Http\Controllers\Api\AuthApiController;
 
-/*
-|--------------------------------------------------------------------------
-| API Routes
-|--------------------------------------------------------------------------
-|
-| Here is where you can register API routes for your application. These
-| routes are loaded by the RouteServiceProvider within a group which
-| is assigned the "api" middleware group. Enjoy building your API!
-|
-*/
+Route::post('login', [AuthApiController::class, 'login']);
 
-/*(Route::get('/user', function (Request $request) {
-    return $request->user();
-})->middleware('auth:api');*/
-
-
-// Route::resource('property','PropertiesController', ['only'=>['index', 'show', 'store', 'update', 'destroy']]);
-// Route::resource('landlord','LandlordsController', ['only'=>['index', 'show', 'store', 'update', 'destroy']]);
-
-// Route::group(['middleware'=>'token'],function(){
-// 	Route::post('import-property','PropertiesController@importProperties');
-// });
+Route::middleware('auth:sanctum')->group(function () {
+    Route::apiResource('properties', PropertyApiController::class);
+    Route::apiResource('tenancies', TenancyApiController::class);
+    Route::apiResource('payments', PaymentApiController::class);
+    Route::apiResource('webhooks', WebhookApiController::class)->only(['index', 'store', 'destroy']);
+});


### PR DESCRIPTION
## Summary
- set up token-based auth via Laravel Sanctum and login endpoint
- expose Property, Tenancy, Payment, and Webhook CRUD API routes
- dispatch webhook jobs on property creation and document the new API

## Testing
- `vendor/bin/phpunit` *(fails: Failed opening required 'vendor/composer/../laravel/framework/src/Illuminate/Support/functions.php')*


------
https://chatgpt.com/codex/tasks/task_e_68954bb17fc4832ea04e956d4667948e