### PR TITLE
Add maintenance request management with notifications

### DIFF
--- a/app/Http/Controllers/MaintenanceRequestController.php
+++ b/app/Http/Controllers/MaintenanceRequestController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\MaintenanceRequest;
+use App\Notifications\MaintenanceStatusUpdated;
+use Illuminate\Http\Request;
+
+class MaintenanceRequestController extends Controller
+{
+    /**
+     * Show form for tenants to create a maintenance request.
+     */
+    public function create()
+    {
+        return view('maintenance.create');
+    }
+
+    /**
+     * Store a newly created maintenance request.
+     */
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'property_id' => 'required|exists:properties,id',
+            'description' => 'required|string',
+        ]);
+
+        if ($tenant = tenant()) {
+            $validated['tenant_id'] = $tenant->id;
+        }
+
+        $validated['status'] = 'pending';
+
+        MaintenanceRequest::create($validated);
+
+        return redirect()->route('maintenance.create')->with('status', 'Request submitted.');
+    }
+
+    /**
+     * Display a listing of maintenance requests for admins.
+     */
+    public function index()
+    {
+        $requests = MaintenanceRequest::with(['property', 'tenant'])->get();
+
+        return view('maintenance.index', compact('requests'));
+    }
+
+    /**
+     * Display a single maintenance request.
+     */
+    public function show(MaintenanceRequest $maintenanceRequest)
+    {
+        return view('maintenance.show', ['request' => $maintenanceRequest]);
+    }
+
+    /**
+     * Update the status of a maintenance request.
+     */
+    public function update(Request $request, MaintenanceRequest $maintenanceRequest)
+    {
+        $data = $request->validate([
+            'status' => 'required|string',
+        ]);
+
+        $maintenanceRequest->update($data);
+
+        if ($maintenanceRequest->tenant) {
+            $maintenanceRequest->tenant->notify(new MaintenanceStatusUpdated($maintenanceRequest));
+        }
+
+        return redirect()->route('maintenance.show', $maintenanceRequest)->with('status', 'Status updated.');
+    }
+}
+

--- a/app/Models/MaintenanceRequest.php
+++ b/app/Models/MaintenanceRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class MaintenanceRequest extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'property_id',
+        'tenant_id',
+        'description',
+        'status',
+    ];
+
+    public function property()
+    {
+        return $this->belongsTo(Property::class);
+    }
+
+    public function tenant()
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+}
+

--- a/app/Notifications/MaintenanceStatusUpdated.php
+++ b/app/Notifications/MaintenanceStatusUpdated.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\MaintenanceRequest;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Messages\VonageMessage;
+use Illuminate\Notifications\Notification;
+
+class MaintenanceStatusUpdated extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(protected MaintenanceRequest $request)
+    {
+    }
+
+    public function via($notifiable): array
+    {
+        return ['mail', 'vonage'];
+    }
+
+    public function toMail($notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Maintenance Request Status Updated')
+            ->line('The status of your maintenance request #'.$this->request->id.' has been updated to '.$this->request->status.'.');
+    }
+
+    public function toVonage($notifiable): VonageMessage
+    {
+        return (new VonageMessage)
+            ->content('Maintenance request #'.$this->request->id.' status: '.$this->request->status);
+    }
+}
+

--- a/database/migrations/2024_05_29_000000_create_maintenance_requests.php
+++ b/database/migrations/2024_05_29_000000_create_maintenance_requests.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('maintenance_requests', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('property_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('tenant_id')->constrained()->cascadeOnDelete();
+            $table->text('description');
+            $table->string('status')->default('pending');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('maintenance_requests');
+    }
+};
+

--- a/resources/views/maintenance/create.blade.php
+++ b/resources/views/maintenance/create.blade.php
@@ -1,0 +1,17 @@
+@extends('layouts.app')
+
+@section('content')
+<h1 class="text-2xl font-bold mb-4">Request Maintenance</h1>
+<form method="POST" action="{{ route('maintenance.store') }}" class="space-y-4">
+    @csrf
+    <div>
+        <label class="block font-medium" for="property_id">Property ID</label>
+        <input type="number" name="property_id" id="property_id" class="border rounded w-full" required>
+    </div>
+    <div>
+        <label class="block font-medium" for="description">Description</label>
+        <textarea name="description" id="description" class="border rounded w-full" required></textarea>
+    </div>
+    <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Submit</button>
+</form>
+@endsection

--- a/resources/views/maintenance/index.blade.php
+++ b/resources/views/maintenance/index.blade.php
@@ -1,0 +1,25 @@
+@extends('layouts.app')
+
+@section('content')
+<h1 class="text-2xl font-bold mb-4">Maintenance Requests</h1>
+<table class="min-w-full bg-white">
+    <thead>
+        <tr>
+            <th class="px-4 py-2">ID</th>
+            <th class="px-4 py-2">Property</th>
+            <th class="px-4 py-2">Tenant</th>
+            <th class="px-4 py-2">Status</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach($requests as $request)
+        <tr>
+            <td class="border px-4 py-2"><a href="{{ route('maintenance.show', $request) }}">{{ $request->id }}</a></td>
+            <td class="border px-4 py-2">{{ $request->property->title ?? 'N/A' }}</td>
+            <td class="border px-4 py-2">{{ $request->tenant->id ?? 'N/A' }}</td>
+            <td class="border px-4 py-2">{{ $request->status }}</td>
+        </tr>
+        @endforeach
+    </tbody>
+</table>
+@endsection

--- a/resources/views/maintenance/show.blade.php
+++ b/resources/views/maintenance/show.blade.php
@@ -1,0 +1,21 @@
+@extends('layouts.app')
+
+@section('content')
+<h1 class="text-2xl font-bold mb-4">Maintenance Request #{{ $request->id }}</h1>
+<p><strong>Property:</strong> {{ $request->property->title ?? 'N/A' }}</p>
+<p><strong>Tenant:</strong> {{ $request->tenant->id ?? 'N/A' }}</p>
+<p class="mb-4"><strong>Description:</strong> {{ $request->description }}</p>
+<form method="POST" action="{{ route('maintenance.update', $request) }}" class="space-y-4">
+    @csrf
+    @method('PUT')
+    <div>
+        <label class="block font-medium" for="status">Status</label>
+        <select name="status" id="status" class="border rounded w-full">
+            <option value="pending" @selected($request->status === 'pending')>Pending</option>
+            <option value="in_progress" @selected($request->status === 'in_progress')>In Progress</option>
+            <option value="completed" @selected($request->status === 'completed')>Completed</option>
+        </select>
+    </div>
+    <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Update</button>
+</form>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\PropertyController;
 use App\Http\Controllers\ContactController;
 use App\Http\Controllers\DiaryController;
 use App\Http\Controllers\AccountController;
+use App\Http\Controllers\MaintenanceRequestController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -41,6 +42,11 @@ Route::middleware(['auth', 'verified', 'role:Admin|Landlord'])->group(function (
     Route::delete('/tenants/{tenant}', [TenantController::class, 'destroy'])->name('tenants.destroy');
     Route::get('/tenants/{tenant}/delete', [TenantController::class, 'delete'])->name('tenants.delete');
     Route::post('/tenants/{tenant}/add-user', [TenantController::class, 'addUser'])->name('tenants.addUser');
+
+    // Maintenance request admin routes
+    Route::get('/maintenance', [MaintenanceRequestController::class, 'index'])->name('maintenance.index');
+    Route::get('/maintenance/{maintenanceRequest}', [MaintenanceRequestController::class, 'show'])->name('maintenance.show');
+    Route::put('/maintenance/{maintenanceRequest}', [MaintenanceRequestController::class, 'update'])->name('maintenance.update');
 });
 
 // Tenant routes (aktonz.ressapp.com, etc.)
@@ -49,6 +55,9 @@ Route::middleware(['auth', 'tenancy', 'role:Tenant'])->group(function () {
     Route::resource('contacts', ContactController::class);
     Route::resource('diary', DiaryController::class);
     Route::resource('accounts', AccountController::class);
+
+    Route::get('maintenance/create', [MaintenanceRequestController::class, 'create'])->name('maintenance.create');
+    Route::post('maintenance', [MaintenanceRequestController::class, 'store'])->name('maintenance.store');
 });
 
 Route::get('/magic-login/{token}', [MagicLoginController::class, 'login'])->name('magic.login');


### PR DESCRIPTION
## Summary
- add maintenance_requests table and model
- implement MaintenanceRequestController with tenant submission and admin management
- notify tenants by email/SMS when request status changes

## Testing
- `php artisan test` *(fails: Failed opening required Illuminate/Support/functions.php)*

------
https://chatgpt.com/codex/tasks/task_e_68954ba71d7c832e8abf7bcca45100ca