### PR TITLE
Fix CI workflow setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,18 +2,24 @@ name: CI
 
 on:
   push:
-    branches: ["*"]
   pull_request:
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.3'
+          coverage: none
+      - name: Prepare application environment
+        run: cp .env.example .env
+
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-interaction
+        run: composer install --prefer-dist --no-progress --no-interaction --no-scripts
+
+      - name: Generate application key
+        run: php artisan key:generate
       - name: Run PHPUnit
         run: ./vendor/bin/phpunit --testdox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,33 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_DATABASE: ressapp
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    env:
+      APP_ENV: testing
+      DB_CONNECTION: mysql
+      DB_HOST: 127.0.0.1
+      DB_PORT: 3306
+      DB_DATABASE: ressapp
+      DB_USERNAME: root
+      DB_PASSWORD: root
     steps:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.3'
+          extensions: mbstring, bcmath, intl, pdo_mysql
           coverage: none
       - name: Prepare application environment
         run: cp .env.example .env


### PR DESCRIPTION
## Summary
- adjust CI trigger to run on all pushes and update checkout action
- install PHP 8.3, prepare Laravel environment, and skip composer scripts during install
- ensure application key is generated before running PHPUnit tests

## Testing
- no automated tests were run (workflow configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68ca1d82449c832e878a35d495083b38