### PR TITLE
Align maintenance request tenant foreign key type

### DIFF
--- a/database/migrations/2024_05_29_000000_create_maintenance_requests.php
+++ b/database/migrations/2024_05_29_000000_create_maintenance_requests.php
@@ -16,7 +16,12 @@ return new class extends Migration
         Schema::create('maintenance_requests', function (Blueprint $table) {
             $table->id();
             $table->foreignId('property_id')->constrained()->cascadeOnDelete();
-            $table->foreignId('tenant_id')->constrained()->cascadeOnDelete();
+            $table->string('tenant_id');
+            $table
+                ->foreign('tenant_id')
+                ->references('id')
+                ->on('tenants')
+                ->cascadeOnDelete();
             $table->text('description');
             $table->string('status')->default('pending');
             $table->timestamps();


### PR DESCRIPTION
## Summary
- ensure the `maintenance_requests.tenant_id` column uses a string to match the `tenants.id` primary key
- define the foreign key constraint explicitly so tenant deletions cascade correctly

## Testing
- php -l database/migrations/2024_05_29_000000_create_maintenance_requests.php

------
https://chatgpt.com/codex/tasks/task_e_68ca21d54ebc832eb8906cfc38b239fc