### PR TITLE
Adjust fix_composer cleanup to preserve lockfile

### DIFF
--- a/fix_composer.sh
+++ b/fix_composer.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-# Remove the vendor directory to ensure a clean state while keeping the lockfile
-rm -rf vendor
+set -euo pipefail
+
+# Remove only the vendor directory to ensure a clean state while keeping composer.lock
+rm -rf vendor/
 
 # Clear Composer cache
 composer clear-cache
 
-# Run the existing setup script to reinstall dependencies via the lockfile
-./setup.sh
+# Reinstall dependencies from the existing lockfile
+composer install --no-interaction --prefer-dist --no-progress


### PR DESCRIPTION
## Summary
- ensure `fix_composer.sh` only removes the `vendor/` directory while keeping `composer.lock`
- reinstall PHP dependencies from the existing lockfile via `composer install`
- enable strict bash options for safer execution

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca229743c8832e8b77a9d9e628a098