### PR TITLE
Align dashboard authentication flow with tests

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -9,7 +9,7 @@ class LoginController extends Controller
 {
     use AuthenticatesUsers;
 
-    protected $redirectTo = '/properties';
+    protected $redirectTo = '/dashboard';
 
     public function __construct()
     {

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,7 +18,7 @@ Route::get('/', function () {
 });
 
 // Single dashboard route for route('dashboard')
-Route::get('/dashboard', [DashboardController::class, 'index'])->middleware(['auth', 'is_admin'])->name('dashboard');
+Route::get('/dashboard', [DashboardController::class, 'index'])->middleware(['auth'])->name('dashboard');
 
 // Central app routes (localhost:8888/)
 Route::middleware('auth')->group(function () {


### PR DESCRIPTION
## Summary
- redirect authenticated users to the dashboard after login
- allow any authenticated user to access the dashboard route without requiring the custom is_admin middleware

## Testing
- Not run (composer install fails in the execution environment: unable to download dependencies from github.com)


------
https://chatgpt.com/codex/tasks/task_e_68ca266cfd58832ebf3ad6744307e52b