### PR TITLE
Fix tenant id migrations

### DIFF
--- a/database/migrations/2025_08_01_000001_add_tenant_id_to_properties_table.php
+++ b/database/migrations/2025_08_01_000001_add_tenant_id_to_properties_table.php
@@ -11,12 +11,11 @@ return new class extends Migration
      */
     public function up(): void
     {
-        /*
-        Schema::table('properties', function (Blueprint $table) {
-            $table->unsignedBigInteger('tenant_id')->nullable()->after('id');
-            $table->foreign('tenant_id')->references('id')->on('tenants')->onDelete('set null');
-        });
-        */
+        if (! Schema::hasColumn('properties', 'tenant_id')) {
+            Schema::table('properties', function (Blueprint $table) {
+                $table->unsignedBigInteger('tenant_id')->nullable()->after('id');
+            });
+        }
     }
 
     /**
@@ -24,9 +23,10 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('properties', function (Blueprint $table) {
-            $table->dropForeign(['tenant_id']);
-            $table->dropColumn('tenant_id');
-        });
+        if (Schema::hasColumn('properties', 'tenant_id')) {
+            Schema::table('properties', function (Blueprint $table) {
+                $table->dropColumn('tenant_id');
+            });
+        }
     }
 };

--- a/database/migrations/2025_08_01_000002_change_tenant_id_column_type_in_properties_table.php
+++ b/database/migrations/2025_08_01_000002_change_tenant_id_column_type_in_properties_table.php
@@ -11,9 +11,11 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('properties', function (Blueprint $table) {
-            $table->string('tenant_id', 255)->nullable()->change();
-        });
+        if (Schema::hasColumn('properties', 'tenant_id')) {
+            Schema::table('properties', function (Blueprint $table) {
+                $table->string('tenant_id', 255)->nullable()->change();
+            });
+        }
     }
 
     /**
@@ -21,8 +23,10 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('properties', function (Blueprint $table) {
-            $table->unsignedBigInteger('tenant_id')->nullable()->change();
-        });
+        if (Schema::hasColumn('properties', 'tenant_id')) {
+            Schema::table('properties', function (Blueprint $table) {
+                $table->unsignedBigInteger('tenant_id')->nullable()->change();
+            });
+        }
     }
 };


### PR DESCRIPTION
## Summary
- ensure the tenant_id column is added to the properties table only when missing
- guard the tenant_id type migration so it only runs when the column exists

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca29969514832ea908c5a5ae829bf5