### PR TITLE
Add migration ensuring invoices date column exists

### DIFF
--- a/database/migrations/2025_08_10_000001_add_date_column_to_invoices_table.php
+++ b/database/migrations/2025_08_10_000001_add_date_column_to_invoices_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('invoices', 'date')) {
+            Schema::table('invoices', function (Blueprint $table) {
+                $table->date('date')->nullable()->after('number');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('invoices', 'date')) {
+            Schema::table('invoices', function (Blueprint $table) {
+                $table->dropColumn('date');
+            });
+        }
+    }
+};


### PR DESCRIPTION
## Summary
- add a safeguard migration that creates the invoices.date column when missing to support invoice scheduling jobs

## Testing
- php artisan test *(fails: Command 'test' is not available without Composer dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ca2cd7a554832ebec2fce13ab0fe97