### PR TITLE
Use date type for diary events

### DIFF
--- a/app/Http/Resources/DiaryEventResource.php
+++ b/app/Http/Resources/DiaryEventResource.php
@@ -12,6 +12,7 @@ class DiaryEventResource extends JsonResource
             'id' => $this->id,
             'title' => $this->title,
             'description' => $this->description,
+            'date' => $this->date,
             'start' => $this->start,
             'end' => $this->end,
             'type' => $this->type,

--- a/app/Models/DiaryEvent.php
+++ b/app/Models/DiaryEvent.php
@@ -10,7 +10,7 @@ class DiaryEvent extends Model
     use HasFactory;
 
     protected $fillable = [
-        'title', 'description', 'start', 'end', 'type', 'user_id', 'property_id', 'contact_id', 'color'
+        'title', 'description', 'date', 'start', 'end', 'type', 'user_id', 'property_id', 'contact_id', 'color'
     ];
 
     public function user()

--- a/database/factories/DiaryEventFactory.php
+++ b/database/factories/DiaryEventFactory.php
@@ -15,7 +15,7 @@ class DiaryEventFactory extends Factory
         return [
             'title' => $this->faker->sentence(3),
             'description' => $this->faker->sentence(8),
-            'date' => $start,
+            'date' => $start->format('Y-m-d'),
             'start' => $start,
             'type' => $this->faker->randomElement(['appointment', 'viewing', 'inspection']),
             'created_at' => now(),

--- a/database/migrations/2025_07_21_000005_create_diary_events_table.php
+++ b/database/migrations/2025_07_21_000005_create_diary_events_table.php
@@ -12,6 +12,7 @@ return new class extends Migration
             $table->id();
             $table->string('title');
             $table->text('description')->nullable();
+            $table->date('date')->nullable();
             $table->dateTime('start');
             $table->dateTime('end')->nullable();
             $table->string('type'); // appointment, viewing, inspection, etc

--- a/database/migrations/2025_07_29_160000_add_date_to_diary_events_table.php
+++ b/database/migrations/2025_07_29_160000_add_date_to_diary_events_table.php
@@ -8,14 +8,18 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::table('diary_events', function (Blueprint $table) {
-            $table->dateTime('date')->nullable()->after('description');
-        });
+        if (! Schema::hasColumn('diary_events', 'date')) {
+            Schema::table('diary_events', function (Blueprint $table) {
+                $table->date('date')->nullable()->after('description');
+            });
+        }
     }
     public function down(): void
     {
-        Schema::table('diary_events', function (Blueprint $table) {
-            $table->dropColumn('date');
-        });
+        if (Schema::hasColumn('diary_events', 'date')) {
+            Schema::table('diary_events', function (Blueprint $table) {
+                $table->dropColumn('date');
+            });
+        }
     }
 };


### PR DESCRIPTION
## Summary
- create the `date` column on `diary_events` as a `date` field in both the original and follow-up migrations
- format the factory's seeded value to match the schema so demo data still loads correctly

## Testing
- php artisan migrate:fresh --seed --force *(fails: Class "Stancl\\Tenancy\\TenancyServiceProvider" not found because the offline vendor tree lacks that package)*

------
https://chatgpt.com/codex/tasks/task_e_68ca2b8f89a8832eadf8228183abff15