### PR TITLE
Resolve invoice date column migration conflict

### DIFF
--- a/database/migrations/2025_07_20_235124_create_invoices_table.php
+++ b/database/migrations/2025_07_20_235124_create_invoices_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->id();
             $table->timestamps();
             $table->string('number')->unique();
-            $table->date('date');
+            $table->date('date')->nullable();
             $table->unsignedBigInteger('contact_id')->nullable();
             $table->unsignedBigInteger('property_id')->nullable();
             $table->decimal('amount', 12, 2);


### PR DESCRIPTION
## Summary
- make the invoices base migration create a nullable date column so it is compatible with the guard migration

## Testing
- php artisan test *(fails: command not available without Composer dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ca3028436c832ebc8bad2f71f9cf5f