### PR TITLE
Update tenancy central domains for Hostinger deployment

### DIFF
--- a/config/tenancy.php
+++ b/config/tenancy.php
@@ -19,6 +19,8 @@ return [
     'central_domains' => [
         '127.0.0.1',
         'localhost',
+        'ressapp.localhost',
+        'darkorange-chinchilla-918430.hostingersite.com',
     ],
 
     /**


### PR DESCRIPTION
## Summary
- add ressapp.localhost and the Hostinger production host to the tenancy central domain list so the central app resolves correctly

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d075aa6ee0832e9d1a4ecc82efe80c