### PR TITLE
Add tenant portal diagnostics and tests

### DIFF
--- a/app/Console/Commands/ListTenants.php
+++ b/app/Console/Commands/ListTenants.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Tenant;
+use Illuminate\Console\Command;
+
+class ListTenants extends Command
+{
+    protected $signature = 'tenant:list {--json : Output tenant details as JSON}';
+
+    protected $description = 'Display all registered tenants and their domains.';
+
+    public function handle(): int
+    {
+        $tenants = Tenant::query()->with('domains')->orderBy('id')->get();
+
+        if ($tenants->isEmpty()) {
+            $this->warn('No tenants have been registered yet.');
+
+            return self::SUCCESS;
+        }
+
+        if ($this->option('json')) {
+            $payload = $tenants->map(function (Tenant $tenant) {
+                return [
+                    'id' => $tenant->id,
+                    'company_name' => $tenant->data['company_name'] ?? null,
+                    'company_email' => $tenant->data['email'] ?? null,
+                    'domains' => $tenant->domains->pluck('domain')->values()->all(),
+                ];
+            })->values();
+
+            $this->line(json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return self::SUCCESS;
+        }
+
+        $rows = $tenants->map(function (Tenant $tenant) {
+            $domains = $tenant->domains->pluck('domain');
+
+            return [
+                'Tenant ID' => $tenant->id,
+                'Company' => $tenant->data['company_name'] ?? '—',
+                'Primary Domain' => $domains->first() ?? '—',
+                'All Domains' => $domains->implode(PHP_EOL) ?: '—',
+            ];
+        })->values()->all();
+
+        $this->table(
+            ['Tenant ID', 'Company', 'Primary Domain', 'All Domains'],
+            array_map(fn ($row) => array_values($row), $rows)
+        );
+
+        $this->info(sprintf('Total tenants: %d', $tenants->count()));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -22,6 +22,7 @@ class Kernel extends ConsoleKernel
         \App\Console\Commands\FixAktonzTenantEmail::class,
         \App\Console\Commands\CreateAktonzTenant::class,
         \App\Console\Commands\FixAktonzTenantData::class,
+        \App\Console\Commands\ListTenants::class,
     ];
 
     protected function schedule(Schedule $schedule)

--- a/app/Http/Controllers/TenantPortalController.php
+++ b/app/Http/Controllers/TenantPortalController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Core\Application;
+use App\Tenancy\TenantDirectory;
+use Framework\Http\Request;
+use Framework\Http\Response;
+
+class TenantPortalController
+{
+    public function login(Request $request, array $context): Response
+    {
+        /** @var Application $app */
+        $app = $context['app'];
+
+        $content = $app->view('tenant.login');
+
+        return Response::view($content);
+    }
+
+    public function dashboard(Request $request, array $context): Response
+    {
+        /** @var Application $app */
+        $app = $context['app'];
+        $user = $app->auth()->user();
+
+        $content = $app->view('tenant.dashboard', [
+            'user' => $user,
+        ]);
+
+        return Response::view($content);
+    }
+
+    public function list(Request $request, array $context): Response
+    {
+        $directory = new TenantDirectory();
+        $tenants = $directory->all();
+
+        /** @var Application $app */
+        $app = $context['app'];
+
+        $content = $app->view('tenant.list', [
+            'tenants' => $tenants,
+        ]);
+
+        return Response::view($content);
+    }
+}

--- a/app/Http/Middleware/TenantAuthenticate.php
+++ b/app/Http/Middleware/TenantAuthenticate.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Framework\Http\Request;
+use Framework\Http\Response;
+
+class TenantAuthenticate
+{
+    public function __invoke(Request $request, callable $next, array $context): Response
+    {
+        $app = $context['app'];
+
+        if (!$app->auth()->check()) {
+            return Response::redirect('/tenant/login');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Tenancy/TenantDirectory.php
+++ b/app/Tenancy/TenantDirectory.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Tenancy;
+
+class TenantDirectory
+{
+    /**
+     * @var array<int, array{slug: string, name: string, domains: string[]}>
+     */
+    private array $tenants;
+
+    public function __construct(?array $tenants = null)
+    {
+        $this->tenants = $tenants ?? self::defaultTenants();
+    }
+
+    /**
+     * @return array<int, array{slug: string, name: string, domains: string[]}>
+     */
+    public function all(): array
+    {
+        return $this->tenants;
+    }
+
+    private static function defaultTenants(): array
+    {
+        return [
+            [
+                'slug' => 'aktonz',
+                'name' => 'Aktonz',
+                'domains' => [
+                    'aktonz.ressapp.localhost:8888',
+                    'aktonz.darkorange-chinchilla-918430.hostingersite.com',
+                ],
+            ],
+            [
+                'slug' => 'haringeyestates',
+                'name' => 'Haringey Estates',
+                'domains' => [
+                    'haringey.ressapp.localhost:8888',
+                ],
+            ],
+        ];
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,13 +3,16 @@
 use App\Core\Application;
 use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\DashboardController;
+use App\Http\Controllers\TenantPortalController;
 use App\Http\Middleware\Authenticate;
+use App\Http\Middleware\TenantAuthenticate;
 use Framework\Http\Response;
 
 $app = new Application(__DIR__ . '/..');
 
 $router = $app->router();
 $router->middleware('auth', [new Authenticate(), '__invoke']);
+$router->middleware('tenant', [new TenantAuthenticate(), '__invoke']);
 
 $router->get('/login', function ($request, array $context) {
     $controller = new LoginController();
@@ -20,6 +23,21 @@ $router->get('/dashboard', function ($request, array $context) {
     $controller = new DashboardController();
     return $controller->index($request, $context);
 }, ['auth']);
+
+$router->get('/tenant/login', function ($request, array $context) {
+    $controller = new TenantPortalController();
+    return $controller->login($request, $context);
+});
+
+$router->get('/tenant/dashboard', function ($request, array $context) {
+    $controller = new TenantPortalController();
+    return $controller->dashboard($request, $context);
+}, ['tenant']);
+
+$router->get('/tenant/list', function ($request, array $context) {
+    $controller = new TenantPortalController();
+    return $controller->list($request, $context);
+});
 
 $router->get('/', function () {
     return Response::redirect('/dashboard', 302);

--- a/config/tenancy.php
+++ b/config/tenancy.php
@@ -19,6 +19,8 @@ return [
     'central_domains' => [
         '127.0.0.1',
         'localhost',
+        'ressapp.localhost',
+        'darkorange-chinchilla-918430.hostingersite.com',
     ],
 
     /**

--- a/resources/views/tenant/dashboard.php
+++ b/resources/views/tenant/dashboard.php
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Tenant Dashboard</title>
+</head>
+<body>
+    <h1>Tenant Dashboard</h1>
+    <?php if (isset($user) && $user !== null): ?>
+        <p>Welcome back, <?php echo htmlspecialchars($user->name, ENT_QUOTES, 'UTF-8'); ?>.</p>
+    <?php else: ?>
+        <p>You are viewing the dashboard as a guest.</p>
+    <?php endif; ?>
+    <ul>
+        <li>Review your tenancy information.</li>
+        <li>Submit maintenance requests.</li>
+        <li>Review statements and payments.</li>
+    </ul>
+</body>
+</html>

--- a/resources/views/tenant/list.php
+++ b/resources/views/tenant/list.php
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Tenant Directory</title>
+</head>
+<body>
+    <h1>Tenant Directory</h1>
+    <p>The following tenants are currently registered in Ressapp:</p>
+    <ul>
+        <?php foreach ($tenants as $tenant): ?>
+            <li>
+                <strong><?php echo htmlspecialchars($tenant['name'], ENT_QUOTES, 'UTF-8'); ?></strong>
+                (<?php echo htmlspecialchars($tenant['slug'], ENT_QUOTES, 'UTF-8'); ?>)
+                <ul>
+                    <?php foreach ($tenant['domains'] as $domain): ?>
+                        <li><?php echo htmlspecialchars($domain, ENT_QUOTES, 'UTF-8'); ?></li>
+                    <?php endforeach; ?>
+                </ul>
+            </li>
+        <?php endforeach; ?>
+    </ul>
+</body>
+</html>

--- a/resources/views/tenant/login.php
+++ b/resources/views/tenant/login.php
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Tenant Login</title>
+</head>
+<body>
+    <h1>Tenant Login</h1>
+    <p>Sign in with your tenant credentials to access the dashboard.</p>
+</body>
+</html>

--- a/routes/landlord.php
+++ b/routes/landlord.php
@@ -10,5 +10,6 @@ Route::middleware(['web', 'auth:landlord'])
     ->group(function () {
         Route::get('/dashboard', [LandlordDashboardController::class, 'index'])
             ->name('dashboard');
+
+        Route::resource('tenants', TenantController::class);
     });
-    Route::resource('tenants', TenantController::class);

--- a/tests/TenantPortalTest.php
+++ b/tests/TenantPortalTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests;
+
+use App\Models\User;
+
+class TenantPortalTest extends TestCase
+{
+    public function testTenantLoginPageLoadsSuccessfully(): void
+    {
+        $response = $this->get('/tenant/login');
+
+        $this->assertStatus($response, 200);
+        $this->assertSee($response, 'Tenant Login');
+    }
+
+    public function testTenantDashboardRequiresAuthentication(): void
+    {
+        $response = $this->get('/tenant/dashboard');
+
+        $this->assertRedirect($response, '/tenant/login');
+    }
+
+    public function testTenantDashboardWelcomesAuthenticatedUser(): void
+    {
+        $user = User::create([
+            'name' => 'Aktonz Tenant',
+            'email' => 'tenant@aktonz.com',
+            'password' => 'secret',
+        ]);
+
+        $response = $this->actingAs($user)->get('/tenant/dashboard');
+
+        $this->assertStatus($response, 200);
+        $this->assertSee($response, 'Tenant Dashboard');
+        $this->assertSee($response, 'Aktonz Tenant');
+    }
+
+    public function testTenantDirectoryListsKnownTenants(): void
+    {
+        $response = $this->get('/tenant/list');
+
+        $this->assertStatus($response, 200);
+        $this->assertSee($response, 'Tenant Directory');
+        $this->assertSee($response, 'Aktonz');
+        $this->assertSee($response, 'aktonz.darkorange-chinchilla-918430.hostingersite.com');
+    }
+}


### PR DESCRIPTION
## Summary
- register tenant login, dashboard, and directory endpoints with dedicated controller and middleware in the bootstrap router
- provide static tenant directory data and HTML views to surface tenant access and Aktonz domain details
- add a tenant portal test suite covering login access control, dashboard rendering, and directory output

## Testing
- ./vendor/bin/phpunit
- php scripts/phpunit-runner.php

------
https://chatgpt.com/codex/tasks/task_e_68d075aa6ee0832e9d1a4ecc82efe80c