### PR TITLE
Avoid loading Vite assets when manifest is missing

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -64,7 +64,10 @@
             }
         </style>
 
-        @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @php($viteManifest = public_path('build/manifest.json'))
+        @if (file_exists($viteManifest))
+            @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @endif
     </head>
     <body>
         <div class="flex-center position-ref full-height">


### PR DESCRIPTION
## Summary
- guard the welcome view's Vite directive so it only runs when the build manifest exists
- prevent HTTP 500s on production instances where assets haven't been compiled yet

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68d08d649230832e86227cfd6eed5d73