### PR TITLE
Add Hostinger deployment workflow

### DIFF
--- a/.github/workflows/deploy-hostinger.yml
+++ b/.github/workflows/deploy-hostinger.yml
@@ -1,0 +1,120 @@
+name: Deploy to Hostinger
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  FTP_SYNC_STATE: .ftp-deploy-sync-state.json
+
+jobs:
+  deploy:
+    name: Upload application to Hostinger
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate deployment secrets
+        id: validate
+        run: |
+          missing=()
+          for name in HOSTINGER_FTP_HOST HOSTINGER_FTP_USERNAME HOSTINGER_FTP_PASSWORD HOSTINGER_FTP_TARGET_DIR; do
+            if [ -z "${!name:-}" ]; then
+              missing+=("$name")
+            fi
+          done
+
+          if [ "${#missing[@]}" -ne 0 ]; then
+            printf '::error::Missing required deployment secrets: %s\n' "${missing[*]}"
+            exit 1
+          fi
+        env:
+          HOSTINGER_FTP_HOST: ${{ secrets.HOSTINGER_FTP_HOST }}
+          HOSTINGER_FTP_USERNAME: ${{ secrets.HOSTINGER_FTP_USERNAME }}
+          HOSTINGER_FTP_PASSWORD: ${{ secrets.HOSTINGER_FTP_PASSWORD }}
+          HOSTINGER_FTP_TARGET_DIR: ${{ secrets.HOSTINGER_FTP_TARGET_DIR }}
+
+      - name: Set up PHP 8.3
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: mbstring, bcmath, intl, pdo_mysql
+          coverage: none
+
+      - name: Install Composer dependencies
+        run: composer install --no-dev --prefer-dist --no-progress --no-interaction --optimize-autoloader
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install Node dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Build frontend assets
+        run: npm run build -- --emptyOutDir
+
+      - name: Remove development-only files before deploy
+        run: |
+          rm -rf node_modules
+          find storage -type f -name '*.log' -delete || true
+
+      - name: Choose transfer protocol
+        id: protocol
+        run: |
+          if [ -z "${HOSTINGER_FTP_PROTOCOL:-}" ]; then
+            echo "value=ftps" >>"$GITHUB_OUTPUT"
+          else
+            echo "value=${HOSTINGER_FTP_PROTOCOL}" >>"$GITHUB_OUTPUT"
+          fi
+        env:
+          HOSTINGER_FTP_PROTOCOL: ${{ secrets.HOSTINGER_FTP_PROTOCOL }}
+
+      - name: Choose transfer port
+        id: port
+        run: |
+          if [ -z "${HOSTINGER_FTP_PORT:-}" ]; then
+            echo "value=21" >>"$GITHUB_OUTPUT"
+          else
+            echo "value=${HOSTINGER_FTP_PORT}" >>"$GITHUB_OUTPUT"
+          fi
+        env:
+          HOSTINGER_FTP_PORT: ${{ secrets.HOSTINGER_FTP_PORT }}
+
+      - name: Deploy to Hostinger
+        uses: SamKirkland/FTP-Deploy-Action@v4
+        with:
+          server: ${{ secrets.HOSTINGER_FTP_HOST }}
+          username: ${{ secrets.HOSTINGER_FTP_USERNAME }}
+          password: ${{ secrets.HOSTINGER_FTP_PASSWORD }}
+          protocol: ${{ steps.protocol.outputs.value }}
+          port: ${{ steps.port.outputs.value }}
+          server-dir: ${{ secrets.HOSTINGER_FTP_TARGET_DIR }}
+          local-dir: .
+          exclude: |
+            **/.git*/**
+            **/.gitignore
+            **/.github/**
+            **/.devcontainer/**
+            **/node_modules/**
+            **/storage/logs/**
+            **/storage/framework/cache/data/**
+            **/storage/framework/sessions/**
+            **/storage/framework/testing/**
+            **/tests/**
+            **/docs/**
+            **/offline/**
+            **/framework/**
+            **/vendor/bin/**
+            **/deps/**
+            **/deps.tar.gz
+          state-name: ${{ env.FTP_SYNC_STATE }}
+          log-level: minimal
+root@542378e9b218:/workspace/ressapp#

--- a/README.md
+++ b/README.md
@@ -38,6 +38,24 @@ A GitHub Actions workflow runs the PHPUnit suite on every push and pull request.
 The static frontend located in `frontend/` is automatically published to GitHub Pages using the workflow in `.github/workflows/pages.yml`.
 Push changes to `main` and visit the repository's Pages environment to view the site.
 
+## Deploying to Hostinger
+
+Pushes to `main` automatically trigger `.github/workflows/deploy-hostinger.yml`, which builds production assets and uploads the
+application to your Hostinger account via FTP/SFTP. Configure the following repository secrets before enabling the workflow:
+
+| Secret | Required | Description |
+| --- | --- | --- |
+| `HOSTINGER_FTP_HOST` | ✅ | Hostname of your Hostinger FTP/SFTP server. |
+| `HOSTINGER_FTP_USERNAME` | ✅ | Username that has write access to the deployment directory. |
+| `HOSTINGER_FTP_PASSWORD` | ✅ | Password or app token for the account above. |
+| `HOSTINGER_FTP_TARGET_DIR` | ✅ | Remote path to your Laravel application's root (for example `domains/example.com/public_html/`). |
+| `HOSTINGER_FTP_PORT` | ❌ | Override the default port (`21`). Set to `22` when using SFTP. |
+| `HOSTINGER_FTP_PROTOCOL` | ❌ | Transfer protocol (`ftps` by default). Use `sftp` if Hostinger requires it. |
+
+After the workflow finishes, the state file `.ftp-deploy-sync-state.json` stored on the server keeps future deployments fast by
+syncing only changed files. Clean up any old log files or caches in `storage/` directly on the server if required—the workflow
+omits them from uploads.
+
 ## Setting up in the Codex environment
 
 To initialize the project when working in Codex or any fresh development container:


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the Laravel app and deploys it to Hostinger over FTP/SFTP
- document the required repository secrets and deployment behaviour in the README

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68d099f03cd0832e8526512a38f8b3a9