### PR TITLE
Use tenancy database for tenant directory

### DIFF
--- a/app/Core/Application.php
+++ b/app/Core/Application.php
@@ -6,12 +6,14 @@ use App\Auth\AuthManager;
 use Framework\Http\Request;
 use Framework\Http\Response;
 use Framework\Routing\Router;
+use Illuminate\Database\ConnectionInterface;
 
 class Application
 {
     private Router $router;
     private AuthManager $auth;
     private string $viewPath;
+    private ?ConnectionInterface $database = null;
 
     public function __construct(string $basePath)
     {
@@ -41,6 +43,16 @@ class Application
         ob_start();
         include $path;
         return (string) ob_get_clean();
+    }
+
+    public function setDatabaseConnection(ConnectionInterface $connection): void
+    {
+        $this->database = $connection;
+    }
+
+    public function database(): ?ConnectionInterface
+    {
+        return $this->database;
     }
 
     public function handle(string $method, string $uri): Response

--- a/app/Http/Controllers/TenantPortalController.php
+++ b/app/Http/Controllers/TenantPortalController.php
@@ -32,9 +32,8 @@ class TenantPortalController
         return Response::view($content);
     }
 
-    public function list(Request $request, array $context): Response
+    public function list(Request $request, array $context, TenantDirectory $directory): Response
     {
-        $directory = new TenantDirectory();
         $tenants = $directory->all();
 
         /** @var Application $app */

--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -2,17 +2,40 @@
 
 namespace App\Models;
 
-use Stancl\Tenancy\Database\Models\Tenant as StanclTenant;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
-class Tenant extends StanclTenant
+if (class_exists(\Stancl\Tenancy\Database\Models\Tenant::class)) {
+    abstract class BaseTenant extends \Stancl\Tenancy\Database\Models\Tenant
+    {
+    }
+} else {
+    abstract class BaseTenant extends Model
+    {
+    }
+}
+
+class Tenant extends BaseTenant
 {
+    protected $table = 'tenants';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'id',
+        'data',
+    ];
+
     protected $casts = [
         'data' => 'array',
     ];
 
-    // Add any future custom logic or relationships here
-    public function domains()
+    public function domains(): HasMany
     {
-        return $this->hasMany(\Stancl\Tenancy\Database\Models\Domain::class);
+        return $this->hasMany(TenantDomain::class, 'tenant_id');
     }
 }

--- a/app/Models/TenantDomain.php
+++ b/app/Models/TenantDomain.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TenantDomain extends Model
+{
+    protected $table = 'domains';
+
+    protected $fillable = [
+        'domain',
+        'tenant_id',
+    ];
+
+    public $timestamps = false;
+
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class, 'tenant_id');
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\TenantPortalController;
 use App\Http\Middleware\Authenticate;
 use App\Http\Middleware\TenantAuthenticate;
+use App\Tenancy\TenantDirectory;
 use Framework\Http\Response;
 
 $app = new Application(__DIR__ . '/..');
@@ -36,7 +37,12 @@ $router->get('/tenant/dashboard', function ($request, array $context) {
 
 $router->get('/tenant/list', function ($request, array $context) {
     $controller = new TenantPortalController();
-    return $controller->list($request, $context);
+
+    $app = $context['app'] ?? null;
+    $connection = $app instanceof Application ? $app->database() : null;
+    $directory = new TenantDirectory($connection);
+
+    return $controller->list($request, $context, $directory);
 });
 
 $router->get('/', function ($request, array $context) {

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,6 +13,7 @@ class DatabaseSeeder extends Seeder
             AdminUserSeeder::class,
             ContactTagGroupSeeder::class,
             DemoDataSeeder::class, // Add demo data seeder
+            TenantSeeder::class,
             CreateSuperAdminSeeder::class,
         ]);
     }

--- a/database/seeders/TenantSeeder.php
+++ b/database/seeders/TenantSeeder.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Tenant;
+use Illuminate\Database\Seeder;
+
+class TenantSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $tenants = [
+            [
+                'id' => 'aktonz',
+                'name' => 'Aktonz',
+                'domains' => [
+                    'aktonz.ressapp.localhost:8888',
+                    'aktonz.darkorange-chinchilla-918430.hostingersite.com',
+                ],
+            ],
+            [
+                'id' => 'haringeyestates',
+                'name' => 'Haringey Estates',
+                'domains' => [
+                    'haringey.ressapp.localhost:8888',
+                    'haringey.example.com',
+                ],
+            ],
+            [
+                'id' => 'demoestate',
+                'name' => 'Demo Estate',
+                'domains' => [
+                    'demo.ressapp.localhost:8888',
+                ],
+            ],
+        ];
+
+        foreach ($tenants as $tenantData) {
+            $tenant = Tenant::query()->updateOrCreate(
+                ['id' => $tenantData['id']],
+                [
+                    'data' => [
+                        'slug' => $tenantData['id'],
+                        'name' => $tenantData['name'],
+                    ],
+                ],
+            );
+
+            $tenant->domains()->delete();
+
+            foreach ($tenantData['domains'] as $domain) {
+                $tenant->domains()->create(['domain' => $domain]);
+            }
+        }
+    }
+}

--- a/tests/TenantPortalTest.php
+++ b/tests/TenantPortalTest.php
@@ -44,5 +44,9 @@ class TenantPortalTest extends TestCase
         $this->assertSee($response, 'Tenant Directory');
         $this->assertSee($response, 'Aktonz');
         $this->assertSee($response, 'aktonz.darkorange-chinchilla-918430.hostingersite.com');
+        $this->assertSee($response, 'Haringey Estates');
+        $this->assertSee($response, 'haringey.example.com');
+        $this->assertSee($response, 'Demo Estate');
+        $this->assertSee($response, 'demo.ressapp.localhost:8888');
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,7 +3,10 @@
 namespace Tests;
 
 use App\Core\Application;
+use Database\Seeders\TenantSeeder;
 use Framework\Http\Response;
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Database\Schema\Blueprint;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
@@ -11,11 +14,15 @@ abstract class TestCase extends BaseTestCase
     use CreatesApplication;
 
     protected Application $app;
+    protected static ?Capsule $capsule = null;
+    protected static bool $tenancySchemaMigrated = false;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->app = $this->createApplication();
+        $this->bootTenancyDatabase();
+        $this->seedTenancyFixtures();
     }
 
     protected function get(string $uri): Response
@@ -43,5 +50,67 @@ abstract class TestCase extends BaseTestCase
     protected function assertSee(Response $response, string $text): void
     {
         self::assertStringContainsString($text, $response->body());
+    }
+
+    private function bootTenancyDatabase(): void
+    {
+        $depsAutoload = dirname(__DIR__) . '/deps/vendor/autoload.php';
+        if (file_exists($depsAutoload)) {
+            require_once $depsAutoload;
+        }
+
+        if (!static::$capsule) {
+            $capsule = new Capsule();
+            $capsule->addConnection([
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'prefix' => '',
+            ]);
+            $capsule->setAsGlobal();
+            $capsule->bootEloquent();
+            static::$capsule = $capsule;
+
+            // Keep the SQLite in-memory connection alive across tests.
+            static::$capsule->getConnection()->getPdo();
+        }
+
+        $this->app->setDatabaseConnection(static::$capsule->getConnection());
+
+        if (!static::$tenancySchemaMigrated) {
+            $schema = static::$capsule->schema();
+
+            if (! $schema->hasTable('tenants')) {
+                $schema->create('tenants', function (Blueprint $table) {
+                    $table->string('id')->primary();
+                    $table->timestamps();
+                    $table->json('data')->nullable();
+                });
+            }
+
+            if (! $schema->hasTable('domains')) {
+                $schema->create('domains', function (Blueprint $table) {
+                    $table->increments('id');
+                    $table->string('domain', 255)->unique();
+                    $table->string('tenant_id');
+                    $table->timestamps();
+                });
+            }
+
+            static::$tenancySchemaMigrated = true;
+        }
+    }
+
+    private function seedTenancyFixtures(): void
+    {
+        if (!static::$capsule) {
+            return;
+        }
+
+        $connection = static::$capsule->getConnection();
+        $connection->table('domains')->delete();
+        $connection->table('tenants')->delete();
+
+        $seeder = new TenantSeeder();
+        $seeder->run();
     }
 }


### PR DESCRIPTION
## Summary
- switch the tenant directory to query tenant and domain data from the tenancy tables instead of static arrays
- seed representative tenant fixtures and expose a reusable database-backed tenant model for tests
- extend the HTTP test harness to bootstrap an in-memory tenancy store so the directory endpoint is validated against multiple tenants

## Testing
- `./deps/vendor/bin/phpunit` *(fails: bundled PHPUnit build relies on deprecated PHP APIs in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9b0815cb8832e837f7d21c9d44c3a