### PR TITLE
Use tenancy repository for tenant directory listings

### DIFF
--- a/app/Http/Controllers/TenantPortalController.php
+++ b/app/Http/Controllers/TenantPortalController.php
@@ -10,6 +10,10 @@ use Illuminate\Support\Facades\Auth;
 
 class TenantPortalController
 {
+    public function __construct(private ?TenantDirectory $directory = null)
+    {
+    }
+
     public function login(Request $request, array $context): Response
     {
         /** @var Application $app */
@@ -35,7 +39,7 @@ class TenantPortalController
 
     public function list(Request $request, array $context): Response
     {
-        $directory = new TenantDirectory();
+        $directory = $this->directory ?? new TenantDirectory();
         $tenants = $directory->all();
 
         /** @var Application $app */

--- a/app/Tenancy/Repositories/DatabaseTenantRepository.php
+++ b/app/Tenancy/Repositories/DatabaseTenantRepository.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Tenancy\Repositories;
+
+use App\Models\Tenant;
+use App\Tenancy\TenantRepository;
+
+class DatabaseTenantRepository implements TenantRepository
+{
+    /**
+     * @return array<int, array{slug: string, name: string, domains: string[]}>
+     */
+    public function allTenants(): array
+    {
+        if (!class_exists(Tenant::class)) {
+            return [];
+        }
+
+        $tenants = [];
+
+        foreach (Tenant::all() as $tenant) {
+            $tenants[] = [
+                'slug' => $this->resolveSlug($tenant),
+                'name' => $this->resolveName($tenant),
+                'domains' => $this->resolveDomains($tenant),
+            ];
+        }
+
+        return $tenants;
+    }
+
+    private function resolveSlug($tenant): string
+    {
+        $data = $tenant->data ?? [];
+
+        if (is_array($data) && isset($data['slug']) && is_string($data['slug'])) {
+            return $data['slug'];
+        }
+
+        if (isset($tenant->id) && is_string($tenant->id)) {
+            return $tenant->id;
+        }
+
+        return (string) ($tenant->slug ?? '');
+    }
+
+    private function resolveName($tenant): string
+    {
+        $data = $tenant->data ?? [];
+
+        if (is_array($data)) {
+            foreach (['name', 'company_name', 'label'] as $key) {
+                if (isset($data[$key]) && is_string($data[$key]) && $data[$key] !== '') {
+                    return $data[$key];
+                }
+            }
+        }
+
+        if (isset($tenant->name) && is_string($tenant->name)) {
+            return $tenant->name;
+        }
+
+        return $this->resolveSlug($tenant);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function resolveDomains($tenant): array
+    {
+        $data = $tenant->data ?? [];
+        $domains = [];
+
+        if (is_array($data) && isset($data['domains']) && is_array($data['domains'])) {
+            $domains = array_values(array_filter($data['domains'], static fn ($domain) => is_string($domain) && $domain !== ''));
+        }
+
+        if ($domains !== []) {
+            return $domains;
+        }
+
+        if (method_exists($tenant, 'domains')) {
+            $relation = $tenant->domains();
+
+            if (is_iterable($relation)) {
+                foreach ($relation as $domain) {
+                    if (is_object($domain) && isset($domain->domain) && is_string($domain->domain)) {
+                        $domains[] = $domain->domain;
+                    }
+                }
+            } elseif (method_exists($relation, 'get')) {
+                foreach ($relation->get() as $domain) {
+                    if (isset($domain->domain) && is_string($domain->domain)) {
+                        $domains[] = $domain->domain;
+                    }
+                }
+            }
+        }
+
+        return $domains;
+    }
+}

--- a/app/Tenancy/Repositories/InMemoryTenantRepository.php
+++ b/app/Tenancy/Repositories/InMemoryTenantRepository.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Tenancy\Repositories;
+
+use App\Tenancy\TenantRepository;
+
+class InMemoryTenantRepository implements TenantRepository
+{
+    /**
+     * @param array<int, array{slug: string, name: string, domains: string[]}> $tenants
+     */
+    public function __construct(private array $tenants = [])
+    {
+    }
+
+    /**
+     * @param array<int, array{slug: string, name: string, domains: string[]}> $tenants
+     */
+    public function seed(array $tenants): void
+    {
+        $this->tenants = array_values($tenants);
+    }
+
+    /**
+     * @return array<int, array{slug: string, name: string, domains: string[]}>
+     */
+    public function allTenants(): array
+    {
+        return array_values($this->tenants);
+    }
+}

--- a/app/Tenancy/TenantDirectory.php
+++ b/app/Tenancy/TenantDirectory.php
@@ -4,14 +4,11 @@ namespace App\Tenancy;
 
 class TenantDirectory
 {
-    /**
-     * @var array<int, array{slug: string, name: string, domains: string[]}>
-     */
-    private array $tenants;
+    private TenantRepository $repository;
 
-    public function __construct(?array $tenants = null)
+    public function __construct(?TenantRepository $repository = null)
     {
-        $this->tenants = $tenants ?? self::defaultTenants();
+        $this->repository = $repository ?? TenantRepositoryManager::getRepository();
     }
 
     /**
@@ -19,27 +16,6 @@ class TenantDirectory
      */
     public function all(): array
     {
-        return $this->tenants;
-    }
-
-    private static function defaultTenants(): array
-    {
-        return [
-            [
-                'slug' => 'aktonz',
-                'name' => 'Aktonz',
-                'domains' => [
-                    'aktonz.ressapp.localhost:8888',
-                    'aktonz.darkorange-chinchilla-918430.hostingersite.com',
-                ],
-            ],
-            [
-                'slug' => 'haringeyestates',
-                'name' => 'Haringey Estates',
-                'domains' => [
-                    'haringey.ressapp.localhost:8888',
-                ],
-            ],
-        ];
+        return $this->repository->allTenants();
     }
 }

--- a/app/Tenancy/TenantRepository.php
+++ b/app/Tenancy/TenantRepository.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Tenancy;
+
+/**
+ * @internal Simple repository contract for fetching tenant directory data.
+ */
+interface TenantRepository
+{
+    /**
+     * @return array<int, array{slug: string, name: string, domains: string[]}>
+     */
+    public function allTenants(): array;
+}

--- a/app/Tenancy/TenantRepositoryManager.php
+++ b/app/Tenancy/TenantRepositoryManager.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Tenancy;
+
+use App\Tenancy\Repositories\DatabaseTenantRepository;
+
+class TenantRepositoryManager
+{
+    private static ?TenantRepository $repository = null;
+
+    public static function setRepository(TenantRepository $repository): void
+    {
+        self::$repository = $repository;
+    }
+
+    public static function clear(): void
+    {
+        self::$repository = null;
+    }
+
+    public static function getRepository(): TenantRepository
+    {
+        if (!self::$repository) {
+            self::$repository = new DatabaseTenantRepository();
+        }
+
+        return self::$repository;
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -4,6 +4,7 @@ use App\Core\Application;
 use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\TenantPortalController;
+use App\Tenancy\TenantDirectory;
 use App\Http\Middleware\Authenticate;
 use Framework\Http\Response;
 use Illuminate\Support\Facades\Auth;
@@ -23,18 +24,20 @@ $router->get('/dashboard', function ($request, array $context) {
     return $controller->index($request, $context);
 }, ['auth:web']);
 
-$router->get('/tenant/login', function ($request, array $context) {
-    $controller = new TenantPortalController();
+$tenantDirectory = new TenantDirectory();
+
+$router->get('/tenant/login', function ($request, array $context) use ($tenantDirectory) {
+    $controller = new TenantPortalController($tenantDirectory);
     return $controller->login($request, $context);
 });
 
-$router->get('/tenant/dashboard', function ($request, array $context) {
-    $controller = new TenantPortalController();
+$router->get('/tenant/dashboard', function ($request, array $context) use ($tenantDirectory) {
+    $controller = new TenantPortalController($tenantDirectory);
     return $controller->dashboard($request, $context);
 }, ['auth:tenant']);
 
-$router->get('/tenant/list', function ($request, array $context) {
-    $controller = new TenantPortalController();
+$router->get('/tenant/list', function ($request, array $context) use ($tenantDirectory) {
+    $controller = new TenantPortalController($tenantDirectory);
     return $controller->list($request, $context);
 });
 

--- a/bootstrap/autoload.php
+++ b/bootstrap/autoload.php
@@ -67,6 +67,7 @@ if (class_exists(\Composer\Autoload\ClassLoader::class, false)) {
         $loader->setPsr4('Tests\\', [$projectRoot.'/tests']);
         $loader->setPsr4('Framework\\', [$projectRoot.'/framework']);
         $loader->setPsr4('PHPUnit\\', [$projectRoot.'/framework/PHPUnit']);
+        $loader->setPsr4('Database\\Seeders\\', [$projectRoot.'/database/seeders']);
         $loader->addClassMap([
             'Tests\\TestCase' => $projectRoot.'/tests/TestCase.php',
         ]);

--- a/database/seeders/TenantFixtures.php
+++ b/database/seeders/TenantFixtures.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Tenancy\Repositories\InMemoryTenantRepository;
+use App\Tenancy\TenantRepositoryManager;
+
+class TenantFixtures
+{
+    public static function seed(): void
+    {
+        $repository = new InMemoryTenantRepository([
+            [
+                'slug' => 'aktonz',
+                'name' => 'Aktonz',
+                'domains' => [
+                    'aktonz.ressapp.localhost:8888',
+                    'aktonz.darkorange-chinchilla-918430.hostingersite.com',
+                ],
+            ],
+            [
+                'slug' => 'haringeyestates',
+                'name' => 'Haringey Estates',
+                'domains' => [
+                    'haringey.ressapp.localhost:8888',
+                ],
+            ],
+            [
+                'slug' => 'oakwoodhomes',
+                'name' => 'Oakwood Homes',
+                'domains' => [
+                    'oakwood.ressapp.localhost:8888',
+                    'oakwoodhomes.example.com',
+                ],
+            ],
+        ]);
+
+        TenantRepositoryManager::setRepository($repository);
+    }
+}

--- a/tests/TenantPortalTest.php
+++ b/tests/TenantPortalTest.php
@@ -42,7 +42,17 @@ class TenantPortalTest extends TestCase
 
         $this->assertStatus($response, 200);
         $this->assertSee($response, 'Tenant Directory');
-        $this->assertSee($response, 'Aktonz');
-        $this->assertSee($response, 'aktonz.darkorange-chinchilla-918430.hostingersite.com');
+
+        foreach (['Aktonz', 'Haringey Estates', 'Oakwood Homes'] as $tenantName) {
+            $this->assertSee($response, $tenantName);
+        }
+
+        foreach ([
+            'aktonz.darkorange-chinchilla-918430.hostingersite.com',
+            'haringey.ressapp.localhost:8888',
+            'oakwoodhomes.example.com',
+        ] as $domain) {
+            $this->assertSee($response, $domain);
+        }
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,8 @@ namespace Tests;
 
 use App\Core\Application;
 use App\Models\User;
+use App\Tenancy\TenantRepositoryManager;
+use Database\Seeders\TenantFixtures;
 use Framework\Http\Response;
 use Illuminate\Support\Facades\Auth;
 use PHPUnit\Framework\TestCase as BaseTestCase;
@@ -23,6 +25,9 @@ abstract class TestCase extends BaseTestCase
         Auth::shouldUse('web');
         Auth::guard('web')->logout();
         Auth::guard('tenant')->logout();
+
+        TenantRepositoryManager::clear();
+        TenantFixtures::seed();
     }
 
     protected function get(string $uri): Response


### PR DESCRIPTION
## Summary
- add a repository abstraction for tenant directory data with database and in-memory implementations
- seed reusable tenant fixtures and wire the tenant directory into the tenant portal routes via dependency injection
- expand tenant portal tests to cover multiple repository-driven tenants

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68d9bafa4cb8832eae6d2f6dba132754