### PR TITLE
Refactor tests to use Laravel-style testing harness

### DIFF
--- a/bootstrap/autoload.php
+++ b/bootstrap/autoload.php
@@ -66,6 +66,7 @@ if (class_exists(\Composer\Autoload\ClassLoader::class, false)) {
         $loader->setPsr4('App\\', [$projectRoot.'/app']);
         $loader->setPsr4('Tests\\', [$projectRoot.'/tests']);
         $loader->setPsr4('Framework\\', [$projectRoot.'/framework']);
+        $loader->setPsr4('Illuminate\\', [$projectRoot.'/framework/Illuminate']);
         $loader->setPsr4('PHPUnit\\', [$projectRoot.'/framework/PHPUnit']);
         $loader->setPsr4('Database\\Seeders\\', [$projectRoot.'/database/seeders']);
         $loader->addClassMap([

--- a/framework/Illuminate/Foundation/Auth/User.php
+++ b/framework/Illuminate/Foundation/Auth/User.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Foundation\Auth;
+
+class User
+{
+    /** @var array<string, mixed> */
+    protected array $attributes = [];
+
+    public function __construct(array $attributes = [])
+    {
+        $this->fill($attributes);
+    }
+
+    public function __get(string $key)
+    {
+        return $this->attributes[$key] ?? null;
+    }
+
+    public function __set(string $key, $value): void
+    {
+        $this->attributes[$key] = $value;
+    }
+
+    public function __isset(string $key): bool
+    {
+        return array_key_exists($key, $this->attributes);
+    }
+
+    public function fill(array $attributes): void
+    {
+        foreach ($attributes as $key => $value) {
+            $this->attributes[$key] = $value;
+        }
+    }
+
+    public function toArray(): array
+    {
+        return $this->attributes;
+    }
+}

--- a/framework/Illuminate/Foundation/Testing/TestCase.php
+++ b/framework/Illuminate/Foundation/Testing/TestCase.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+use App\Core\Application;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Testing\TestResponse;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    protected Application $app;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app = $this->createApplication();
+    }
+
+    protected function tearDown(): void
+    {
+        unset($this->app);
+
+        parent::tearDown();
+    }
+
+    abstract protected function createApplication(): Application;
+
+    protected function call(string $method, string $uri, array $data = [], array $headers = []): TestResponse
+    {
+        $response = $this->app->handle(strtoupper($method), $uri);
+
+        return new TestResponse($response);
+    }
+
+    protected function get(string $uri, array $headers = []): TestResponse
+    {
+        return $this->call('GET', $uri, [], $headers);
+    }
+
+    protected function post(string $uri, array $data = [], array $headers = []): TestResponse
+    {
+        return $this->call('POST', $uri, $data, $headers);
+    }
+
+    protected function actingAs($user, string $guard = 'web'): static
+    {
+        Auth::guard($guard)->login($user);
+        Auth::shouldUse($guard);
+
+        return $this;
+    }
+}

--- a/framework/Illuminate/Notifications/Notifiable.php
+++ b/framework/Illuminate/Notifications/Notifiable.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Illuminate\Notifications;
+
+trait Notifiable
+{
+}

--- a/framework/Illuminate/Testing/TestResponse.php
+++ b/framework/Illuminate/Testing/TestResponse.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Illuminate\Testing;
+
+use Framework\Http\Response;
+use PHPUnit\Framework\AssertionFailedError;
+
+class TestResponse
+{
+    private Response $baseResponse;
+
+    public function __construct(Response $response)
+    {
+        $this->baseResponse = $response;
+    }
+
+    public function status(): int
+    {
+        return $this->baseResponse->status();
+    }
+
+    public function content(): string
+    {
+        return $this->baseResponse->body();
+    }
+
+    public function header(string $name): ?string
+    {
+        return $this->baseResponse->header($name);
+    }
+
+    public function assertStatus(int $expected): self
+    {
+        if ($this->status() !== $expected) {
+            throw new AssertionFailedError(
+                sprintf('Expected response status %d but received %d.', $expected, $this->status())
+            );
+        }
+
+        return $this;
+    }
+
+    public function assertRedirect(string $location): self
+    {
+        $status = $this->status();
+        if ($status < 300 || $status >= 400) {
+            throw new AssertionFailedError(
+                sprintf('Response status %d is not a redirect status code.', $status)
+            );
+        }
+
+        $actual = $this->header('location');
+
+        if ($actual !== $location) {
+            throw new AssertionFailedError(
+                sprintf('Expected redirect to [%s] but redirected to [%s].', $location, (string) $actual)
+            );
+        }
+
+        return $this;
+    }
+
+    public function assertSee(string $value): self
+    {
+        if (strpos($this->content(), $value) === false) {
+            throw new AssertionFailedError(
+                sprintf('Failed asserting that the response contains "%s".', $value)
+            );
+        }
+
+        return $this;
+    }
+}

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -3,11 +3,26 @@
 namespace Tests;
 
 use App\Core\Application;
+use App\Models\User;
+use App\Tenancy\TenantRepositoryManager;
+use Database\Seeders\TenantFixtures;
+use Illuminate\Support\Facades\Auth;
 
 trait CreatesApplication
 {
     public function createApplication(): Application
     {
-        return require __DIR__ . '/../bootstrap/app.php';
+        $app = require __DIR__ . '/../bootstrap/app.php';
+
+        User::truncate();
+
+        Auth::shouldUse('web');
+        Auth::guard('web')->logout();
+        Auth::guard('tenant')->logout();
+
+        TenantRepositoryManager::clear();
+        TenantFixtures::seed();
+
+        return $app;
     }
 }

--- a/tests/DashboardTest.php
+++ b/tests/DashboardTest.php
@@ -10,14 +10,14 @@ class DashboardTest extends TestCase
     public function testLoginPageLoads(): void
     {
         $response = $this->get('/login');
-        $this->assertStatus($response, 200);
-        $this->assertSee($response, 'Login');
+        $response->assertStatus(200)
+            ->assertSee('Login');
     }
 
     public function testDashboardRequiresAuthentication(): void
     {
         $response = $this->get('/dashboard');
-        $this->assertRedirect($response, '/login');
+        $response->assertRedirect('/login');
     }
 
     public function testAuthenticatedUserCanSeeDashboard(): void
@@ -29,7 +29,7 @@ class DashboardTest extends TestCase
         ]);
 
         $response = $this->actingAs($user)->get('/dashboard');
-        $this->assertStatus($response, 200);
-        $this->assertSee($response, 'Dashboard');
+        $response->assertStatus(200)
+            ->assertSee('Dashboard');
     }
 }

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -8,8 +8,8 @@ class ExampleTest extends TestCase
     {
         $response = $this->get('/');
 
-        $this->assertStatus($response, 200);
-        $this->assertSee($response, 'Modern Estate Agency Software');
-        $this->assertSee($response, 'Get Started Free');
+        $response->assertStatus(200)
+            ->assertSee('Modern Estate Agency Software')
+            ->assertSee('Get Started Free');
     }
 }

--- a/tests/TenantPortalTest.php
+++ b/tests/TenantPortalTest.php
@@ -10,15 +10,15 @@ class TenantPortalTest extends TestCase
     {
         $response = $this->get('/tenant/login');
 
-        $this->assertStatus($response, 200);
-        $this->assertSee($response, 'Tenant Login');
+        $response->assertStatus(200)
+            ->assertSee('Tenant Login');
     }
 
     public function testTenantDashboardRequiresAuthentication(): void
     {
         $response = $this->get('/tenant/dashboard');
 
-        $this->assertRedirect($response, '/tenant/login');
+        $response->assertRedirect('/tenant/login');
     }
 
     public function testTenantDashboardWelcomesAuthenticatedUser(): void
@@ -31,20 +31,20 @@ class TenantPortalTest extends TestCase
 
         $response = $this->actingAs($user, 'tenant')->get('/tenant/dashboard');
 
-        $this->assertStatus($response, 200);
-        $this->assertSee($response, 'Tenant Dashboard');
-        $this->assertSee($response, 'Aktonz Tenant');
+        $response->assertStatus(200)
+            ->assertSee('Tenant Dashboard')
+            ->assertSee('Aktonz Tenant');
     }
 
     public function testTenantDirectoryListsKnownTenants(): void
     {
         $response = $this->get('/tenant/list');
 
-        $this->assertStatus($response, 200);
-        $this->assertSee($response, 'Tenant Directory');
+        $response->assertStatus(200)
+            ->assertSee('Tenant Directory');
 
         foreach (['Aktonz', 'Haringey Estates', 'Oakwood Homes'] as $tenantName) {
-            $this->assertSee($response, $tenantName);
+            $response->assertSee($tenantName);
         }
 
         foreach ([
@@ -52,7 +52,7 @@ class TenantPortalTest extends TestCase
             'haringey.ressapp.localhost:8888',
             'oakwoodhomes.example.com',
         ] as $domain) {
-            $this->assertSee($response, $domain);
+            $response->assertSee($domain);
         }
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,58 +2,9 @@
 
 namespace Tests;
 
-use App\Core\Application;
-use App\Models\User;
-use App\Tenancy\TenantRepositoryManager;
-use Database\Seeders\TenantFixtures;
-use Framework\Http\Response;
-use Illuminate\Support\Facades\Auth;
-use PHPUnit\Framework\TestCase as BaseTestCase;
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
-
-    protected Application $app;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->app = $this->createApplication();
-
-        User::truncate();
-        Auth::shouldUse('web');
-        Auth::guard('web')->logout();
-        Auth::guard('tenant')->logout();
-
-        TenantRepositoryManager::clear();
-        TenantFixtures::seed();
-    }
-
-    protected function get(string $uri): Response
-    {
-        return $this->app->handle('GET', $uri);
-    }
-
-    protected function actingAs($user, string $guard = 'web'): self
-    {
-        Auth::guard($guard)->login($user);
-        return $this;
-    }
-
-    protected function assertStatus(Response $response, int $expected): void
-    {
-        self::assertSame($expected, $response->status());
-    }
-
-    protected function assertRedirect(Response $response, string $location): void
-    {
-        $this->assertStatus($response, 302);
-        self::assertSame($location, $response->header('location'));
-    }
-
-    protected function assertSee(Response $response, string $text): void
-    {
-        self::assertStringContainsString($text, $response->body());
-    }
 }


### PR DESCRIPTION
## Summary
- swap the custom Tests\TestCase for one extending Illuminate's testing base and add lightweight Laravel testing stubs
- bootstrap tenancy fixtures and authentication guards from CreatesApplication
- rewrite feature tests to use Laravel-style response assertions

## Testing
- php vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d9c2e04154832e9e8d592db6f66368