### PR TITLE
Update Pages workflow to build frontend assets before upload

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,10 +20,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build frontend assets
+        run: npm run build
       - name: Upload frontend artifact
         uses: actions/upload-pages-artifact@v3
+        if: ${{ hashFiles('public/build/**') != '' }}
         with:
-          path: frontend
+          path: public/build
 
   deploy:
     needs: build


### PR DESCRIPTION
## Summary
- configure the Pages build job to install Node.js dependencies and run the Vite build
- upload the generated `public/build` assets and skip the upload if no build output is produced

## Testing
- npm ci
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9d9cd0fa8832ea9fee86b2590d0ba