### PR TITLE
Seed tenants via tenancy models

### DIFF
--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -2,15 +2,17 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Stancl\Tenancy\Database\Models\Tenant as StanclTenant;
 
 class Tenant extends StanclTenant
 {
+    use HasFactory;
+
     protected $casts = [
         'data' => 'array',
     ];
 
-    // Add any future custom logic or relationships here
     public function domains()
     {
         return $this->hasMany(\Stancl\Tenancy\Database\Models\Domain::class);

--- a/database/factories/TenantFactory.php
+++ b/database/factories/TenantFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Tenant;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class TenantFactory extends Factory
+{
+    protected $model = Tenant::class;
+
+    public function definition(): array
+    {
+        $slug = str_replace('.', '_', uniqid('tenant_', true));
+
+        return [
+            'id' => $slug,
+            'slug' => $slug,
+            'name' => ucfirst(str_replace('_', ' ', $slug)),
+            'domains' => [],
+        ];
+    }
+
+}

--- a/database/seeders/TenantFixtures.php
+++ b/database/seeders/TenantFixtures.php
@@ -2,14 +2,17 @@
 
 namespace Database\Seeders;
 
-use App\Tenancy\Repositories\InMemoryTenantRepository;
-use App\Tenancy\TenantRepositoryManager;
+use App\Models\Tenant;
 
 class TenantFixtures
 {
     public static function seed(): void
     {
-        $repository = new InMemoryTenantRepository([
+        Tenant::query()->each(static function (Tenant $tenant): void {
+            $tenant->delete();
+        });
+
+        $tenants = [
             [
                 'slug' => 'aktonz',
                 'name' => 'Aktonz',
@@ -33,8 +36,22 @@ class TenantFixtures
                     'oakwoodhomes.example.com',
                 ],
             ],
-        ]);
+        ];
 
-        TenantRepositoryManager::setRepository($repository);
+        foreach ($tenants as $tenantData) {
+            $tenant = Tenant::factory()->create([
+                'id' => $tenantData['slug'],
+            ]);
+
+            $tenant->forceFill([
+                'slug' => $tenantData['slug'],
+                'name' => $tenantData['name'],
+                'domains' => $tenantData['domains'],
+            ])->save();
+
+            foreach ($tenantData['domains'] as $domain) {
+                $tenant->domains()->updateOrCreate(['domain' => $domain]);
+            }
+        }
     }
 }

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -43,15 +43,19 @@ trait CreatesApplication
 
         $app['config']->set('database.default', env('DB_CONNECTION', 'sqlite'));
         $app['config']->set('database.connections.sqlite.database', env('DB_DATABASE', $databasePath));
+        $app['config']->set('database.connections.central', $app['config']->get('database.connections.sqlite'));
+        $app['config']->set('tenancy.database.central_connection', $app['config']->get('database.default'));
 
-        $userMigrations = [
+        $migrations = [
             'database/migrations/2014_10_12_000000_create_users_table.php',
+            'database/migrations/2019_09_15_000010_create_tenants_table.php',
+            'database/migrations/2019_09_15_000020_create_domains_table.php',
             'database/migrations/2025_07_19_000000_add_email_verified_at_to_users_table.php',
             'database/migrations/2025_07_29_000001_add_is_admin_to_users_table.php',
             'database/migrations/2025_08_01_000001_add_login_token_to_users_table.php',
         ];
 
-        foreach ($userMigrations as $migrationPath) {
+        foreach ($migrations as $migrationPath) {
             Artisan::call('migrate', [
                 '--database' => $app['config']->get('database.default'),
                 '--force' => true,


### PR DESCRIPTION
## Summary
- add an Eloquent factory for tenants and seed fixtures using real tenant and domain records
- enable the Tenant model to use factories and configure tests to run tenancy migrations with the database repository

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d9e3a808cc832e9a85f6583ca65510