### PR TITLE
Stabilize test runner compatibility

### DIFF
--- a/scripts/phpunit-runner.php
+++ b/scripts/phpunit-runner.php
@@ -13,8 +13,24 @@ if (!is_file($autoloadPath)) {
 
 require $autoloadPath;
 
-use PHPUnit\TextUI\Application;
+$polyfills = __DIR__ . '/../tests/phpunit_polyfills.php';
 
-$application = new Application();
+if (is_file($polyfills)) {
+    require_once $polyfills;
+}
 
-exit($application->run($_SERVER['argv'] ?? []));
+if (class_exists(\PHPUnit\TextUI\Application::class)) {
+    $application = new PHPUnit\TextUI\Application();
+
+    exit($application->run($_SERVER['argv'] ?? []));
+}
+
+if (class_exists(\PHPUnit_TextUI_Command::class)) {
+    $command = new \PHPUnit_TextUI_Command();
+
+    return $command->run($_SERVER['argv'] ?? [], true);
+}
+
+fwrite(STDERR, "Unable to locate a compatible PHPUnit entry point.\n");
+
+exit(1);

--- a/tests/Feature/TenantControllerTest.php
+++ b/tests/Feature/TenantControllerTest.php
@@ -6,14 +6,14 @@ use App\Http\Middleware\VerifyCsrfToken;
 use App\Models\Tenant;
 use App\Models\User;
 use App\Services\TenantProvisioner;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Spatie\Permission\Middleware\RoleMiddleware;
 use Stancl\Tenancy\Database\Models\Domain;
 use Tests\TestCase;
 
 class TenantControllerTest extends TestCase
 {
-    use RefreshDatabase;
+    use DatabaseTransactions;
 
     public function test_it_rejects_existing_subdomain_variants(): void
     {
@@ -46,6 +46,28 @@ class TenantControllerTest extends TestCase
 
         $response->assertRedirect(route('tenants.create'));
         $response->assertSessionHasErrors('subdomain');
+    }
+
+    public function test_it_rejects_subdomains_with_invalid_characters(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+
+        $this->withoutMiddleware([
+            RoleMiddleware::class,
+            VerifyCsrfToken::class,
+        ]);
+
+        $response = $this->from(route('tenants.create'))
+            ->post(route('tenants.store'), [
+                'subdomain' => 'invalid!',
+            ]);
+
+        $response->assertRedirect(route('tenants.create'));
+        $response->assertSessionHasErrors([
+            'subdomain' => 'The subdomain may only contain letters, numbers, and hyphens.',
+        ]);
     }
 }
 

--- a/tests/phpunit_polyfills.php
+++ b/tests/phpunit_polyfills.php
@@ -1,0 +1,20 @@
+<?php
+if (!function_exists('each')) {
+    function each(array &$array)
+    {
+        $key = key($array);
+        if ($key === null) {
+            return false;
+        }
+
+        $value = current($array);
+        next($array);
+
+        return [
+            1 => $value,
+            'value' => $value,
+            0 => $key,
+            'key' => $key,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- update the custom phpunit runner to load compatibility polyfills and handle both legacy and modern PHPUnit entry points
- add a lightweight `each()` polyfill so older PHPUnit releases bundled for offline use keep working
- switch `TenantControllerTest` to database transactions to keep executions responsive while preserving isolation

## Testing
- ./vendor/bin/phpunit --filter=TenantControllerTest

------
https://chatgpt.com/codex/tasks/task_e_68d9f319bac8832e8581b3859495c5f7