### PR TITLE
Generate unique company IDs via shared helper

### DIFF
--- a/app/Support/CompanyIdGenerator.php
+++ b/app/Support/CompanyIdGenerator.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Tenant;
+
+class CompanyIdGenerator
+{
+    public static function generate(): string
+    {
+        do {
+            $candidate = (string) random_int(1000, 999999);
+        } while (Tenant::query()->where('data->company_id', $candidate)->exists());
+
+        return $candidate;
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable CompanyIdGenerator helper and apply it in the admin controller and tenant provisioner
- ensure new tenants persist their generated company IDs by populating virtual columns directly
- cover the creation flow with a feature test that seeds a conflicting ID and verifies a unique value is assigned

## Testing
- vendor/bin/phpunit --filter CompanyControllerTest

------
https://chatgpt.com/codex/tasks/task_e_68da12c163f8832ead3fd2607545256d