### PR TITLE
Adjust inspection routes for agent portal

### DIFF
--- a/app/Http/Controllers/InspectionController.php
+++ b/app/Http/Controllers/InspectionController.php
@@ -12,13 +12,17 @@ class InspectionController extends Controller
     public function index()
     {
         $inspections = Inspection::with('property')->where('agent_id', auth()->id())->get();
-        return view('inspections.index', compact('inspections'));
+        $routePrefix = $this->routePrefix();
+
+        return view('inspections.index', compact('inspections', 'routePrefix'));
     }
 
     public function create()
     {
         $inspection = new Inspection();
-        return view('inspections.edit', compact('inspection'));
+        $routePrefix = $this->routePrefix();
+
+        return view('inspections.edit', compact('inspection', 'routePrefix'));
     }
 
     public function store(Request $request)
@@ -52,13 +56,15 @@ class InspectionController extends Controller
             $agent->notify(new InspectionScheduled($inspection));
         }
 
-        return redirect()->route('inspections.index');
+        return redirect()->route($this->routePrefix().'.index');
     }
 
     public function edit(Inspection $inspection)
     {
         $inspection->load('items');
-        return view('inspections.edit', compact('inspection'));
+        $routePrefix = $this->routePrefix();
+
+        return view('inspections.edit', compact('inspection', 'routePrefix'));
     }
 
     public function update(Request $request, Inspection $inspection)
@@ -86,6 +92,11 @@ class InspectionController extends Controller
             ]);
         }
 
-        return redirect()->route('inspections.index');
+        return redirect()->route($this->routePrefix().'.index');
+    }
+
+    private function routePrefix(): string
+    {
+        return request()->routeIs('agent.*') ? 'agent.inspections' : 'inspections';
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,12 +6,16 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
+use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable
 {
     use HasApiTokens;
     use HasFactory;
     use Notifiable;
+    use HasRoles;
+
+    protected $guard_name = 'web';
 
     protected $fillable = [
         'name',

--- a/database/factories/InspectionFactory.php
+++ b/database/factories/InspectionFactory.php
@@ -13,10 +13,9 @@ class InspectionFactory extends Factory
     {
         return [
             'property_id' => \App\Models\Property::factory(),
-            'date' => $this->faker->dateTimeBetween('-1 month', '+1 month'),
-            'result' => $this->faker->sentence(6),
-            'created_at' => now(),
-            'updated_at' => now(),
+            'agent_id' => \App\Models\User::factory(),
+            'scheduled_at' => $this->faker->dateTimeBetween('-1 week', '+1 week'),
+            'status' => $this->faker->randomElement(['pending', 'completed']),
         ];
     }
 }

--- a/resources/views/inspections/edit.blade.php
+++ b/resources/views/inspections/edit.blade.php
@@ -1,9 +1,11 @@
 @extends('layouts.app')
 
 @section('content')
+@php($routePrefix = $routePrefix ?? 'inspections')
+
 <div class="container mx-auto p-4">
     <h1 class="text-2xl font-bold mb-4">{{ $inspection->exists ? 'Edit' : 'Create' }} Inspection</h1>
-    <form method="POST" enctype="multipart/form-data" action="{{ $inspection->exists ? route('inspections.update', $inspection) : route('inspections.store') }}" class="space-y-4">
+    <form method="POST" enctype="multipart/form-data" action="{{ $inspection->exists ? route($routePrefix . '.update', $inspection) : route($routePrefix . '.store') }}" class="space-y-4">
         @csrf
         @if($inspection->exists)
             @method('PUT')

--- a/resources/views/inspections/index.blade.php
+++ b/resources/views/inspections/index.blade.php
@@ -1,6 +1,8 @@
 @extends('layouts.app')
 
 @section('content')
+@php($routePrefix = $routePrefix ?? 'inspections')
+
 <div class="container mx-auto p-4">
     <h1 class="text-2xl font-bold mb-4">Inspections</h1>
     <table class="min-w-full bg-white">
@@ -18,7 +20,7 @@
                 <td class="px-4 py-2">{{ $inspection->property->title ?? 'N/A' }}</td>
                 <td class="px-4 py-2">{{ $inspection->scheduled_at->format('Y-m-d H:i') }}</td>
                 <td class="px-4 py-2">{{ $inspection->status }}</td>
-                <td class="px-4 py-2"><a href="{{ route('inspections.edit', $inspection) }}" class="text-blue-600">Edit</a></td>
+                <td class="px-4 py-2"><a href="{{ route($routePrefix . '.edit', $inspection) }}" class="text-blue-600">Edit</a></td>
             </tr>
             @endforeach
         </tbody>

--- a/routes/web.php
+++ b/routes/web.php
@@ -121,7 +121,11 @@ Route::group([
     Route::resource('tenants', TenantController::class);
 });
 
-Route::group(['middleware' => ['tenancy', 'preventAccessFromCentralDomains', 'role:Agent']], function () {
+Route::group([
+    'middleware' => ['tenancy', 'preventAccessFromCentralDomains', 'role:Agent'],
+    'prefix' => 'agent',
+    'as' => 'agent.',
+], function () {
     Route::resource('inspections', InspectionController::class);
 });
 

--- a/tests/Feature/InspectionAccessTest.php
+++ b/tests/Feature/InspectionAccessTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Spatie\Permission\Middleware\RoleMiddleware;
+use Stancl\Tenancy\Middleware\InitializeTenancyByDomain;
+use Stancl\Tenancy\Middleware\PreventAccessFromCentralDomains;
+use Tests\TestCase;
+
+class InspectionAccessTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::dropIfExists('model_has_roles');
+        Schema::dropIfExists('roles');
+        Schema::dropIfExists('model_has_permissions');
+        Schema::dropIfExists('permissions');
+        Schema::dropIfExists('inspections');
+        Schema::dropIfExists('properties');
+
+        Schema::create('permissions', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('guard_name')->default('web');
+            $table->timestamps();
+        });
+
+        Schema::create('model_has_permissions', function (Blueprint $table): void {
+            $table->unsignedBigInteger('permission_id');
+            $table->string('model_type');
+            $table->unsignedBigInteger('model_id');
+        });
+
+        Schema::create('roles', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('guard_name')->default('web');
+            $table->timestamps();
+        });
+
+        Schema::create('model_has_roles', function (Blueprint $table): void {
+            $table->unsignedBigInteger('role_id');
+            $table->string('model_type');
+            $table->unsignedBigInteger('model_id');
+        });
+
+        Schema::create('properties', function (Blueprint $table): void {
+            $table->id();
+            $table->string('title')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('inspections', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('property_id')->nullable();
+            $table->unsignedBigInteger('agent_id');
+            $table->timestamp('scheduled_at')->nullable();
+            $table->string('status')->default('pending');
+            $table->timestamps();
+        });
+    }
+
+    public function test_tenant_user_can_view_tenant_inspections_index(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this
+            ->withoutMiddleware([
+                InitializeTenancyByDomain::class,
+                RoleMiddleware::class,
+            ])
+            ->actingAs($user)
+            ->get('/inspections');
+
+        $response->assertOk();
+    }
+
+    public function test_agent_user_can_view_agent_inspections_index(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this
+            ->withoutMiddleware([
+                InitializeTenancyByDomain::class,
+                PreventAccessFromCentralDomains::class,
+                RoleMiddleware::class,
+            ])
+            ->actingAs($user)
+            ->get('/agent/inspections');
+
+        $response->assertOk();
+    }
+
+    public function test_agent_inspection_route_has_agent_prefix_and_middleware(): void
+    {
+        $route = app('router')->getRoutes()->getByName('agent.inspections.index');
+
+        $this->assertNotNull($route);
+        $this->assertSame('agent/inspections', $route->uri());
+
+        $middleware = $route->gatherMiddleware();
+
+        $this->assertTrue(
+            $this->middlewareContains($middleware, InitializeTenancyByDomain::class, 'tenancy'),
+            'Agent route should include tenancy middleware.'
+        );
+        $this->assertTrue(
+            $this->middlewareContains($middleware, PreventAccessFromCentralDomains::class, 'preventAccessFromCentralDomains'),
+            'Agent route should block central domains.'
+        );
+        $this->assertContains('role:Agent', $middleware, 'Agent route should enforce agent role.');
+    }
+
+    public function test_tenant_inspection_route_still_uses_tenant_middleware(): void
+    {
+        $route = app('router')->getRoutes()->getByName('inspections.index');
+
+        $this->assertNotNull($route);
+        $this->assertSame('inspections', $route->uri());
+
+        $middleware = $route->gatherMiddleware();
+
+        $this->assertTrue(
+            $this->middlewareContains($middleware, InitializeTenancyByDomain::class, 'tenancy'),
+            'Tenant route should include tenancy middleware.'
+        );
+        $this->assertContains('role:Tenant', $middleware, 'Tenant route should enforce tenant role.');
+    }
+
+    private function middlewareContains(array $middleware, string $class, string $alias): bool
+    {
+        return in_array($class, $middleware, true) || in_array($alias, $middleware, true);
+    }
+}


### PR DESCRIPTION
## Summary
- add an agent-specific prefix to the inspection resource and make controller/views respect the current route namespace
- update supporting models/factories for role-aware redirects and data creation
- cover tenant and agent inspection access with new feature tests

## Testing
- ./vendor/bin/phpunit --filter InspectionAccessTest

------
https://chatgpt.com/codex/tasks/task_e_68da1af275b8832eb08f5530db7cc012