### PR TITLE
Add Aktonz tenant login page to marketing site

### DIFF
--- a/resources/js/marketing/App.vue
+++ b/resources/js/marketing/App.vue
@@ -11,6 +11,7 @@
                     <button class="nav-link" type="button" @click="scrollTo('pricing')">Pricing</button>
                 </nav>
                 <div class="header-ctas">
+                    <router-link class="secondary" to="/aktonz/login" @click="trackNav('header_tenant_login')">Tenant login</router-link>
                     <router-link class="secondary" to="/signup" @click="trackNav('header_login')">Start trial</router-link>
                     <button class="primary" type="button" @click="goToDemo">Book a demo</button>
                 </div>
@@ -28,6 +29,7 @@
                 <div class="footer-links">
                     <router-link to="/" @click="trackNav('footer_home')">Home</router-link>
                     <router-link to="/signup" @click="trackNav('footer_signup')">Start trial</router-link>
+                    <router-link to="/aktonz/login" @click="trackNav('footer_tenant_login')">Tenant login</router-link>
                     <a href="mailto:sales@ressapp.com" @click="trackNav('footer_email')">Contact</a>
                 </div>
             </div>

--- a/resources/js/marketing/router.js
+++ b/resources/js/marketing/router.js
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import HomeView from './views/HomeView.vue';
 import SignupView from './views/SignupView.vue';
+import TenantLoginView from './views/TenantLoginView.vue';
 
 const history = createWebHistory(import.meta.env.BASE_URL ?? '/');
 
@@ -16,6 +17,11 @@ const router = createRouter({
             path: '/signup',
             name: 'signup',
             component: SignupView,
+        },
+        {
+            path: '/aktonz/login',
+            name: 'aktonz-login',
+            component: TenantLoginView,
         },
     ],
     scrollBehavior() {

--- a/resources/js/marketing/styles.css
+++ b/resources/js/marketing/styles.css
@@ -71,6 +71,7 @@ body.marketing-body {
 
 .header-ctas .primary,
 .hero-ctas .primary,
+.tenant-login__links .primary,
 .lead-form button,
 .trial-form button {
     background: linear-gradient(135deg, #38bdf8, #0ea5e9);
@@ -85,6 +86,7 @@ body.marketing-body {
 
 .header-ctas .primary:hover,
 .hero-ctas .primary:hover,
+.tenant-login__links .primary:hover,
 .lead-form button:hover,
 .trial-form button:hover {
     transform: translateY(-2px);
@@ -432,5 +434,147 @@ textarea {
     .app-footer__inner {
         flex-direction: column;
         gap: 1.5rem;
+    }
+}
+
+.tenant-login {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 4rem 1.5rem 3rem;
+    color: #0f172a;
+}
+
+.tenant-login__hero {
+    text-align: center;
+    color: #f8fafc;
+    margin-bottom: 2.5rem;
+}
+
+.tenant-login__eyebrow {
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    font-size: 0.8rem;
+    color: #38bdf8;
+    margin-bottom: 1rem;
+}
+
+.tenant-login__hero h1 {
+    font-size: clamp(2.2rem, 4vw, 3.2rem);
+    margin-bottom: 1rem;
+}
+
+.tenant-login__hero p {
+    max-width: 620px;
+    margin: 0 auto;
+    font-size: 1.05rem;
+    color: rgba(226, 232, 240, 0.9);
+}
+
+.tenant-login__card {
+    background: #ffffff;
+    border-radius: 1.25rem;
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    box-shadow: 0 30px 60px rgba(15, 23, 42, 0.12);
+}
+
+.tenant-login__card-body {
+    padding: clamp(1.75rem, 4vw, 2.75rem);
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.tenant-login__card-body h2 {
+    margin: 0;
+    font-size: 1.75rem;
+}
+
+.tenant-login__links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.tenant-login__links .primary {
+    text-decoration: none;
+    text-align: center;
+    min-width: 200px;
+}
+
+.tenant-login__alt {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.65rem 1.2rem;
+    border-radius: 999px;
+    font-weight: 600;
+    background: rgba(15, 23, 42, 0.08);
+    color: #0f172a;
+    text-decoration: none;
+    transition: background 0.2s ease, transform 0.15s ease;
+}
+
+.tenant-login__alt:hover {
+    background: rgba(15, 23, 42, 0.12);
+    transform: translateY(-2px);
+}
+
+.tenant-login__bookmark {
+    margin: 0;
+    color: #475569;
+    line-height: 1.6;
+}
+
+.tenant-login__bookmark code {
+    background: rgba(148, 163, 184, 0.2);
+    color: #0f172a;
+    padding: 0.2rem 0.45rem;
+    border-radius: 0.5rem;
+    font-size: 0.95rem;
+}
+
+.tenant-login__tips {
+    margin: 0;
+    padding-left: 1.2rem;
+    color: #475569;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.tenant-login__support {
+    margin-top: 3rem;
+    background: rgba(15, 23, 42, 0.04);
+    border-radius: 1rem;
+    padding: 2rem;
+    color: #0f172a;
+}
+
+.tenant-login__support h2 {
+    margin-top: 0;
+    margin-bottom: 0.75rem;
+}
+
+.tenant-login__support a {
+    color: #0ea5e9;
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.tenant-login__support a:hover {
+    text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+    .tenant-login {
+        padding-top: 3rem;
+    }
+
+    .tenant-login__links {
+        flex-direction: column;
+    }
+
+    .tenant-login__links .primary,
+    .tenant-login__alt {
+        width: 100%;
     }
 }

--- a/resources/js/marketing/views/TenantLoginView.vue
+++ b/resources/js/marketing/views/TenantLoginView.vue
@@ -1,0 +1,100 @@
+<template>
+    <div class="tenant-login">
+        <section class="tenant-login__hero">
+            <p class="tenant-login__eyebrow">Aktonz tenant portal</p>
+            <h1>Log in to your Ressapp tenant workspace</h1>
+            <p>Securely access rent statements, maintenance updates, and documents shared by the Aktonz lettings team.</p>
+        </section>
+
+        <section class="tenant-login__card" aria-labelledby="tenant-login-card-title">
+            <div class="tenant-login__card-body">
+                <h2 id="tenant-login-card-title">Tenant app login</h2>
+                <p>
+                    Use the links below to open the Aktonz tenant login page in a new tab. Sign in with the email address and
+                    password you received during onboarding.
+                </p>
+                <div class="tenant-login__links">
+                    <a
+                        class="primary"
+                        :href="loginUrl"
+                        target="_blank"
+                        rel="noopener"
+                        @click="trackLogin('primary')"
+                    >
+                        Open Aktonz login
+                    </a>
+                    <a
+                        class="tenant-login__alt"
+                        :href="fallbackUrl"
+                        target="_blank"
+                        rel="noopener"
+                        @click="trackLogin('fallback')"
+                    >
+                        Try ressapp.com login
+                    </a>
+                </div>
+                <p class="tenant-login__bookmark">
+                    Bookmark <code>{{ loginHost }}</code> for fast access. If the primary domain is unavailable, you can also use
+                    <code>{{ fallbackHost }}</code>.
+                </p>
+                <ul class="tenant-login__tips">
+                    <li>Use a modern browser such as Chrome, Edge, or Safari for the best experience.</li>
+                    <li>Select “Forgot password” on the login screen if you need to reset your credentials.</li>
+                    <li>Keep your two-factor authentication device handy if your account has MFA enabled.</li>
+                </ul>
+            </div>
+        </section>
+
+        <section class="tenant-login__support" aria-labelledby="tenant-login-support-title">
+            <h2 id="tenant-login-support-title">Need help?</h2>
+            <p>
+                Email the Aktonz support team at
+                <a href="mailto:support@aktonz.com" @click="trackSupport">support@aktonz.com</a>
+                or call your property manager if you run into issues signing in.
+            </p>
+        </section>
+    </div>
+</template>
+
+<script setup>
+import { inject, onMounted } from 'vue';
+
+const analytics = inject('analytics');
+const sessionId = inject('marketingSession');
+
+const loginHost = 'aktonz.darkorange-chinchilla-918430.hostingersite.com';
+const fallbackHost = 'aktonz.ressapp.com';
+const loginUrl = `https://${loginHost}/login`;
+const fallbackUrl = `https://${fallbackHost}/login`;
+
+function trackLogin(target) {
+    analytics?.track(
+        'marketing.tenant_login_click',
+        {
+            tenant: 'aktonz',
+            target,
+        },
+        sessionId,
+    );
+}
+
+function trackSupport() {
+    analytics?.track(
+        'marketing.tenant_login_support',
+        {
+            tenant: 'aktonz',
+        },
+        sessionId,
+    );
+}
+
+onMounted(() => {
+    analytics?.track(
+        'marketing.tenant_login_view',
+        {
+            tenant: 'aktonz',
+        },
+        sessionId,
+    );
+});
+</script>


### PR DESCRIPTION
## Summary
- add a dedicated Aktonz tenant login page to the marketing bundle with analytics hooks
- expose the page in the router, header, and footer navigation
- style the new login experience and extend shared button styles

## Testing
- npm run build:marketing

------
https://chatgpt.com/codex/tasks/task_e_68e195a38a10832e8250bfa533c55c0a