### PR TITLE
Fix CI phpunit path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ jobs:
         run: composer install --prefer-dist --no-progress --no-interaction --no-scripts
 
       - name: Run tests
-        run: php vendor/phpunit/phpunit/phpunit --testdox
+        run: vendor/bin/phpunit --testdox


### PR DESCRIPTION
## Summary
- update the CI workflow to invoke PHPUnit from vendor/bin so the executable exists after composer install

## Testing
- vendor/bin/phpunit --testdox

------
https://chatgpt.com/codex/tasks/task_e_68e19ffaa830832eae2a5a0ba9b3f0fb