### PR TITLE
Fix tenant login marketing view markup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ jobs:
         run: composer install --prefer-dist --no-progress --no-interaction --no-scripts
 
       - name: Run tests
-        run: php vendor/phpunit/phpunit/phpunit --testdox
+        run: vendor/bin/phpunit --testdox

--- a/resources/js/marketing/views/TenantLoginView.vue
+++ b/resources/js/marketing/views/TenantLoginView.vue
@@ -17,21 +17,8 @@
                     <a
                         v-for="link in loginLinks"
                         :key="link.id"
-                        :class="link.className"
                         :href="link.href"
                         :class="link.alt ? 'tenant-login__alt' : 'primary'"
-                        :href="link.href"
-                        target="_blank"
-                        rel="noopener"
-                        @click="trackLogin(link.id)"
-                    >
-                        {{ link.label }}
-                    </a>
-                </div>
-                <p class="tenant-login__bookmark">
-                    Bookmark <code>{{ primaryHost }}</code> for fast access. If that link is unavailable, you can also try
-                        class="primary"
-                        :href="loginUrl"
                         target="_blank"
                         rel="noopener"
                         @click="trackLogin(link.id)"
@@ -75,30 +62,13 @@ const loginLinks = [
     {
         id: 'primary',
         label: 'Open Aktonz login',
-        href: `https://${primaryHost}`,
+        href: `https://${primaryHost}/login`,
     },
     {
         id: 'fallback',
         label: 'Try aktonz.ressapp.com login',
         href: `https://${fallbackHost}/login`,
         alt: true,
-    },
-];
-const loginHost = 'aktonz.darkorange-chinchilla-918430.hostingersite.com';
-const fallbackHost = 'aktonz.ressapp.com';
-
-const loginLinks = [
-    {
-        id: 'primary',
-        label: 'Open Aktonz login',
-        className: 'primary',
-        href: `https://${primaryHost}/login`,
-    },
-    {
-        id: 'fallback',
-        label: 'Try ressapp.com login',
-        className: 'tenant-login__alt',
-        href: `https://${fallbackHost}/login`,
     },
 ];
 


### PR DESCRIPTION
## Summary
- clean up the tenant login marketing view to remove duplicated attributes and stale markup
- ensure the login links point directly to the /login endpoints and maintain alternate styling metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e19ffaa830832eae2a5a0ba9b3f0fb