### PR TITLE
Fix CI by installing SQLite extensions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.3'
-          extensions: mbstring, bcmath, intl, pdo_mysql
+          extensions: mbstring, bcmath, intl, pdo_mysql, sqlite, pdo_sqlite
           coverage: none
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-interaction --no-scripts


### PR DESCRIPTION
## Summary
- ensure the CI workflow installs the sqlite and pdo_sqlite PHP extensions so sqlite-backed tests can run

## Testing
- vendor/bin/phpunit --testdox

------
https://chatgpt.com/codex/tasks/task_e_68e1afc6c6dc832ea8f66ef870e31c00