### PR TITLE
Implement dynamic property syndication and contact messaging integrations

### DIFF
--- a/app/Jobs/SendContactCommunication.php
+++ b/app/Jobs/SendContactCommunication.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Contact;
+use App\Models\ContactCommunication;
+use App\Services\Messaging\CommunicationManager;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\App;
+use Throwable;
+
+class SendContactCommunication implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        public Contact $contact,
+        public string $channel,
+        public array $payload,
+        public ?int $userId = null,
+        public ?int $communicationId = null,
+    ) {
+    }
+
+    public function handle(): void
+    {
+        /** @var CommunicationManager $manager */
+        $manager = App::make(CommunicationManager::class);
+
+        $communication = $this->communicationId
+            ? ContactCommunication::find($this->communicationId)
+            : $this->contact->communications()->create([
+                'user_id' => $this->userId,
+                'communication' => $this->payload['body'] ?? '',
+                'subject' => $this->payload['subject'] ?? null,
+                'channel' => $this->channel,
+                'status' => 'pending',
+            ]);
+
+        if (! $communication) {
+            return;
+        }
+
+        try {
+            $result = $manager->send($this->contact, $this->channel, $this->payload);
+            $communication->update([
+                'status' => $result->success ? 'delivered' : 'failed',
+                'provider' => $result->provider,
+                'provider_message_id' => $result->messageId,
+                'delivered_at' => $result->success ? now() : null,
+                'meta' => $result->meta,
+            ]);
+        } catch (Throwable $exception) {
+            $communication->update([
+                'status' => 'failed',
+                'meta' => ['exception' => $exception->getMessage()],
+            ]);
+            throw $exception;
+        }
+    }
+}

--- a/app/Mail/ContactCommunicationMail.php
+++ b/app/Mail/ContactCommunicationMail.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class ContactCommunicationMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(public string $subjectLine, public string $body)
+    {
+    }
+
+    public function build(): self
+    {
+        return $this->subject($this->subjectLine)
+            ->view('emails.contact_communication')
+            ->with(['content' => $this->body]);
+    }
+}

--- a/app/Models/ContactCommunication.php
+++ b/app/Models/ContactCommunication.php
@@ -5,11 +5,31 @@ use Illuminate\Database\Eloquent\Model;
 
 class ContactCommunication extends Model
 {
-    protected $fillable = ['contact_id', 'user_id', 'communication'];
-    public function contact() {
+    protected $fillable = [
+        'contact_id',
+        'user_id',
+        'communication',
+        'channel',
+        'subject',
+        'provider',
+        'provider_message_id',
+        'status',
+        'delivered_at',
+        'meta',
+    ];
+
+    protected $casts = [
+        'meta' => 'array',
+        'delivered_at' => 'datetime',
+    ];
+
+    public function contact()
+    {
         return $this->belongsTo(Contact::class);
     }
-    public function user() {
+
+    public function user()
+    {
         return $this->belongsTo(User::class);
     }
 }

--- a/app/Models/Property.php
+++ b/app/Models/Property.php
@@ -5,8 +5,10 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use App\Models\PropertyChannel;
 
 class Property extends Model
 {
@@ -90,7 +92,17 @@ class Property extends Model
      */
     public function features(): HasMany
     {
-        return $this->hasMany(PropertyFeature::class);
+        return $this->hasMany(PropertyFeature::class)->with('catalog');
+    }
+
+    /**
+     * Channels the property is syndicated to.
+     */
+    public function channels()
+    {
+        return $this->belongsToMany(PropertyChannel::class, 'property_channel_property')
+            ->withPivot(['status', 'payload', 'last_synced_at'])
+            ->withTimestamps();
     }
 
     /**

--- a/app/Models/PropertyChannel.php
+++ b/app/Models/PropertyChannel.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class PropertyChannel extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name', 'slug', 'handler', 'is_active'];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+    ];
+
+    public function properties(): BelongsToMany
+    {
+        return $this->belongsToMany(Property::class, 'property_channel_property')
+            ->withPivot(['status', 'payload', 'last_synced_at'])
+            ->withTimestamps();
+    }
+}

--- a/app/Models/PropertyFeature.php
+++ b/app/Models/PropertyFeature.php
@@ -6,8 +6,25 @@ use Illuminate\Database\Eloquent\Model;
 
 class PropertyFeature extends Model
 {
-    protected $fillable = ['property_id', 'name', 'value'];
-    public function property() {
+    protected $fillable = [
+        'property_id',
+        'feature_catalog_id',
+        'name',
+        'value',
+        'meta',
+    ];
+
+    protected $casts = [
+        'meta' => 'array',
+    ];
+
+    public function property()
+    {
         return $this->belongsTo(Property::class);
+    }
+
+    public function catalog()
+    {
+        return $this->belongsTo(PropertyFeatureCatalog::class, 'feature_catalog_id');
     }
 }

--- a/app/Models/PropertyFeatureCatalog.php
+++ b/app/Models/PropertyFeatureCatalog.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class PropertyFeatureCatalog extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name', 'slug', 'portal_key', 'description'];
+
+    public function features(): HasMany
+    {
+        return $this->hasMany(PropertyFeature::class, 'feature_catalog_id');
+    }
+}

--- a/app/Models/PropertyMedia.php
+++ b/app/Models/PropertyMedia.php
@@ -6,7 +6,21 @@ use Illuminate\Database\Eloquent\Model;
 
 class PropertyMedia extends Model
 {
-    protected $fillable = ['property_id', 'file_path', 'type', 'order'];
+    protected $fillable = [
+        'property_id',
+        'file_path',
+        'type',
+        'disk',
+        'order',
+        'caption',
+        'is_primary',
+        'conversions',
+    ];
+
+    protected $casts = [
+        'is_primary' => 'boolean',
+        'conversions' => 'array',
+    ];
 
     public function property()
     {

--- a/app/Services/Media/PropertyMediaGallery.php
+++ b/app/Services/Media/PropertyMediaGallery.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Services\Media;
+
+use App\Models\Property;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Arr;
+
+class PropertyMediaGallery
+{
+    public function attach(Property $property, array $files, array $captions = [], ?int $primaryIndex = null): void
+    {
+        if (empty($files)) {
+            return;
+        }
+
+        $order = (int) $property->media()->max('order');
+
+        foreach ($files as $index => $file) {
+            if (! $file instanceof UploadedFile) {
+                continue;
+            }
+
+            $storedPath = $file->store('property_media/'.$property->id, 'public');
+
+            $media = $property->media()->create([
+                'file_path' => $storedPath,
+                'type' => $file->getClientMimeType(),
+                'disk' => 'public',
+                'order' => ++$order,
+                'caption' => Arr::get($captions, $index),
+                'is_primary' => $primaryIndex !== null && (int) $primaryIndex === (int) $index,
+            ]);
+
+            if ($media->is_primary) {
+                $property->media()
+                    ->where('id', '!=', $media->id)
+                    ->update(['is_primary' => false]);
+            }
+        }
+    }
+}

--- a/app/Services/Messaging/Channels/EmailChannel.php
+++ b/app/Services/Messaging/Channels/EmailChannel.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Services\Messaging\Channels;
+
+use App\Mail\ContactCommunicationMail;
+use App\Models\Contact;
+use App\Services\Messaging\CommunicationChannel;
+use App\Services\Messaging\CommunicationResult;
+use Illuminate\Support\Facades\Mail;
+
+class EmailChannel implements CommunicationChannel
+{
+    public function send(Contact $contact, array $payload): CommunicationResult
+    {
+        $subject = $payload['subject'] ?? 'Message from Ressapp';
+        $body = $payload['body'] ?? '';
+
+        Mail::to($contact->email)->send(new ContactCommunicationMail($subject, $body));
+
+        return new CommunicationResult(true, 'mail', null, [
+            'subject' => $subject,
+        ]);
+    }
+}

--- a/app/Services/Messaging/Channels/SmsChannel.php
+++ b/app/Services/Messaging/Channels/SmsChannel.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Services\Messaging\Channels;
+
+use App\Models\Contact;
+use App\Services\Messaging\CommunicationChannel;
+use App\Services\Messaging\CommunicationResult;
+use Illuminate\Support\Facades\Http;
+
+class SmsChannel implements CommunicationChannel
+{
+    public function send(Contact $contact, array $payload): CommunicationResult
+    {
+        $config = config('services.twilio');
+        $message = $payload['body'] ?? '';
+
+        $response = Http::withBasicAuth($config['sid'] ?? '', $config['token'] ?? '')
+            ->post($config['endpoint'] ?? '', [
+                'To' => $contact->phone,
+                'From' => $config['from'] ?? null,
+                'Body' => $message,
+            ]);
+
+        $success = $response->successful();
+
+        return new CommunicationResult(
+            $success,
+            'twilio',
+            $response->json('sid') ?? null,
+            ['status' => $response->status(), 'body' => $response->json()]
+        );
+    }
+}

--- a/app/Services/Messaging/CommunicationChannel.php
+++ b/app/Services/Messaging/CommunicationChannel.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Services\Messaging;
+
+use App\Models\Contact;
+
+interface CommunicationChannel
+{
+    public function send(Contact $contact, array $payload): CommunicationResult;
+}

--- a/app/Services/Messaging/CommunicationManager.php
+++ b/app/Services/Messaging/CommunicationManager.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Services\Messaging;
+
+use App\Models\Contact;
+use Illuminate\Support\Facades\App;
+use InvalidArgumentException;
+
+class CommunicationManager
+{
+    /**
+     * @param array<string, class-string<CommunicationChannel>> $channels
+     */
+    public function __construct(private readonly array $channels = [])
+    {
+    }
+
+    public function send(Contact $contact, string $channel, array $payload): CommunicationResult
+    {
+        $map = $this->channels ?: config('communications.channels', []);
+
+        if (! isset($map[$channel])) {
+            throw new InvalidArgumentException("Channel {$channel} is not supported");
+        }
+
+        $handlerClass = $map[$channel];
+        /** @var CommunicationChannel $handler */
+        $handler = App::make($handlerClass);
+
+        return $handler->send($contact, $payload);
+    }
+}

--- a/app/Services/Messaging/CommunicationResult.php
+++ b/app/Services/Messaging/CommunicationResult.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Services\Messaging;
+
+class CommunicationResult
+{
+    public function __construct(
+        public readonly bool $success,
+        public readonly string $provider,
+        public readonly ?string $messageId = null,
+        public readonly array $meta = []
+    ) {
+    }
+}

--- a/app/Services/Portals/PortalPublisher.php
+++ b/app/Services/Portals/PortalPublisher.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Services\Portals;
+
+use App\Models\Property;
+
+interface PortalPublisher
+{
+    public function publish(Property $property): PortalPublisherResult;
+}

--- a/app/Services/Portals/PortalPublisherManager.php
+++ b/app/Services/Portals/PortalPublisherManager.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Services\Portals;
+
+use App\Models\Property;
+use App\Models\PropertyChannel;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\App;
+
+class PortalPublisherManager
+{
+    /**
+     * Publish a property to a specific channel using its configured handler.
+     */
+    public function publish(Property $property, PropertyChannel $channel): PortalPublisherResult
+    {
+        $handler = $channel->handler;
+
+        if (! $channel->is_active) {
+            return new PortalPublisherResult(false, null, ['reason' => 'Channel is disabled']);
+        }
+
+        if (empty($handler) || ! class_exists($handler)) {
+            return new PortalPublisherResult(true, null, ['note' => 'No handler configured']);
+        }
+
+        /** @var PortalPublisher $publisher */
+        $publisher = App::make($handler);
+
+        return $publisher->publish($property);
+    }
+}

--- a/app/Services/Portals/PortalPublisherResult.php
+++ b/app/Services/Portals/PortalPublisherResult.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Services\Portals;
+
+class PortalPublisherResult
+{
+    public function __construct(
+        public readonly bool $success,
+        public readonly ?string $providerMessageId = null,
+        public readonly array $meta = []
+    ) {
+    }
+}

--- a/app/Services/Portals/RightmovePortalPublisher.php
+++ b/app/Services/Portals/RightmovePortalPublisher.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Services\Portals;
+
+use App\Models\Property;
+use Illuminate\Support\Facades\Http;
+
+class RightmovePortalPublisher implements PortalPublisher
+{
+    public function publish(Property $property): PortalPublisherResult
+    {
+        $config = config('services.rightmove');
+        if (empty($config['endpoint'])) {
+            return new PortalPublisherResult(false, null, ['reason' => 'Rightmove endpoint not configured']);
+        }
+
+        $response = Http::withHeaders([
+            'X-API-KEY' => $config['api_key'] ?? null,
+            'X-API-SECRET' => $config['api_secret'] ?? null,
+        ])->post($config['endpoint'], $this->buildPayload($property));
+
+        $success = $response->successful();
+
+        return new PortalPublisherResult(
+            $success,
+            $response->json('message_id') ?? null,
+            ['status' => $response->status(), 'body' => $response->json()]
+        );
+    }
+
+    protected function buildPayload(Property $property): array
+    {
+        return [
+            'id' => $property->id,
+            'title' => $property->title,
+            'price' => $property->price,
+            'address' => $property->address,
+            'city' => $property->city,
+            'postcode' => $property->postcode,
+            'bedrooms' => $property->bedrooms,
+            'bathrooms' => $property->bathrooms,
+            'type' => $property->type,
+            'status' => $property->status,
+            'features' => $property->features->map(fn ($feature) => $feature->catalog?->portal_key ?? $feature->name)->filter()->values(),
+            'media' => $property->media->map(fn ($media) => [
+                'url' => \Storage::disk($media->disk)->url($media->file_path),
+                'caption' => $media->caption,
+                'is_primary' => $media->is_primary,
+            ])->toArray(),
+        ];
+    }
+}

--- a/app/Services/Portals/ZooplaPortalPublisher.php
+++ b/app/Services/Portals/ZooplaPortalPublisher.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Services\Portals;
+
+use App\Models\Property;
+use Illuminate\Support\Facades\Http;
+
+class ZooplaPortalPublisher implements PortalPublisher
+{
+    public function publish(Property $property): PortalPublisherResult
+    {
+        $config = config('services.zoopla');
+        if (empty($config['endpoint'])) {
+            return new PortalPublisherResult(false, null, ['reason' => 'Zoopla endpoint not configured']);
+        }
+
+        $response = Http::withToken($config['api_key'] ?? null)
+            ->post($config['endpoint'], $this->buildPayload($property));
+
+        $success = $response->successful();
+
+        return new PortalPublisherResult(
+            $success,
+            $response->json('message_id') ?? null,
+            ['status' => $response->status(), 'body' => $response->json()]
+        );
+    }
+
+    protected function buildPayload(Property $property): array
+    {
+        return [
+            'property_id' => $property->id,
+            'summary' => $property->description,
+            'price' => $property->price,
+            'location' => [
+                'address' => $property->address,
+                'city' => $property->city,
+                'postcode' => $property->postcode,
+                'latitude' => $property->latitude,
+                'longitude' => $property->longitude,
+            ],
+            'rooms' => [
+                'bedrooms' => $property->bedrooms,
+                'bathrooms' => $property->bathrooms,
+            ],
+            'features' => $property->features->map(fn ($feature) => [
+                'code' => $feature->catalog?->portal_key ?? $feature->name,
+                'value' => $feature->value,
+            ])->toArray(),
+            'media' => $property->media->map(fn ($media) => [
+                'url' => \Storage::disk($media->disk)->url($media->file_path),
+                'caption' => $media->caption,
+                'primary' => $media->is_primary,
+            ])->toArray(),
+        ];
+    }
+}

--- a/config/communications.php
+++ b/config/communications.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'channels' => [
+        'email' => App\Services\Messaging\Channels\EmailChannel::class,
+        'sms' => App\Services\Messaging\Channels\SmsChannel::class,
+    ],
+];

--- a/config/services.php
+++ b/config/services.php
@@ -70,6 +70,13 @@ return [
 
     ],
 
+    'twilio' => [
+        'sid' => env('TWILIO_SID'),
+        'token' => env('TWILIO_TOKEN'),
+        'from' => env('TWILIO_FROM'),
+        'endpoint' => env('TWILIO_ENDPOINT', 'https://api.twilio.com/2010-04-01/Accounts/'.env('TWILIO_SID').'/Messages.json'),
+    ],
+
     'onfido' => [
         'api_token' => env('ONFIDO_API_TOKEN'),
         'webhook_secret' => env('ONFIDO_WEBHOOK_SECRET'),

--- a/database/migrations/2024_01_01_000001_create_property_feature_catalogs_table.php
+++ b/database/migrations/2024_01_01_000001_create_property_feature_catalogs_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('property_feature_catalogs', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->string('portal_key')->nullable();
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('property_feature_catalogs');
+    }
+};

--- a/database/migrations/2024_01_01_000002_add_feature_catalog_to_property_features_table.php
+++ b/database/migrations/2024_01_01_000002_add_feature_catalog_to_property_features_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        if (! Schema::hasTable('property_features')) {
+            return;
+        }
+
+        Schema::table('property_features', function (Blueprint $table) {
+            if (! Schema::hasColumn('property_features', 'feature_catalog_id')) {
+                $table->foreignId('feature_catalog_id')
+                    ->nullable()
+                    ->after('property_id')
+                    ->constrained('property_feature_catalogs')
+                    ->nullOnDelete();
+            }
+
+            if (! Schema::hasColumn('property_features', 'meta')) {
+                $table->json('meta')->nullable()->after('value');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('property_features')) {
+            return;
+        }
+
+        Schema::table('property_features', function (Blueprint $table) {
+            if (Schema::hasColumn('property_features', 'feature_catalog_id')) {
+                $table->dropForeign(['feature_catalog_id']);
+                $table->dropColumn('feature_catalog_id');
+            }
+
+            if (Schema::hasColumn('property_features', 'meta')) {
+                $table->dropColumn('meta');
+            }
+        });
+    }
+};

--- a/database/migrations/2024_01_01_000003_add_gallery_columns_to_property_media_table.php
+++ b/database/migrations/2024_01_01_000003_add_gallery_columns_to_property_media_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        if (! Schema::hasTable('property_media')) {
+            return;
+        }
+
+        Schema::table('property_media', function (Blueprint $table) {
+            if (! Schema::hasColumn('property_media', 'disk')) {
+                $table->string('disk')->default('public')->after('type');
+            }
+            if (! Schema::hasColumn('property_media', 'caption')) {
+                $table->string('caption')->nullable()->after('order');
+            }
+            if (! Schema::hasColumn('property_media', 'is_primary')) {
+                $table->boolean('is_primary')->default(false)->after('caption');
+            }
+            if (! Schema::hasColumn('property_media', 'conversions')) {
+                $table->json('conversions')->nullable()->after('is_primary');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('property_media')) {
+            return;
+        }
+
+        Schema::table('property_media', function (Blueprint $table) {
+            foreach (['disk', 'caption', 'is_primary', 'conversions'] as $column) {
+                if (Schema::hasColumn('property_media', $column)) {
+                    $table->dropColumn($column);
+                }
+            }
+        });
+    }
+};

--- a/database/migrations/2024_01_01_000004_create_property_channels_tables.php
+++ b/database/migrations/2024_01_01_000004_create_property_channels_tables.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('property_channels', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->string('handler')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+
+        Schema::create('property_channel_property', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('property_id')->constrained()->onDelete('cascade');
+            $table->foreignId('property_channel_id')->constrained('property_channels')->onDelete('cascade');
+            $table->string('status')->default('pending');
+            $table->json('payload')->nullable();
+            $table->timestamp('last_synced_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('property_channel_property');
+        Schema::dropIfExists('property_channels');
+    }
+};

--- a/database/migrations/2024_01_01_000005_add_delivery_metadata_to_contact_communications_table.php
+++ b/database/migrations/2024_01_01_000005_add_delivery_metadata_to_contact_communications_table.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        if (! Schema::hasTable('contact_communications')) {
+            return;
+        }
+
+        Schema::table('contact_communications', function (Blueprint $table) {
+            if (! Schema::hasColumn('contact_communications', 'channel')) {
+                $table->string('channel')->default('internal')->after('communication');
+            }
+            if (! Schema::hasColumn('contact_communications', 'subject')) {
+                $table->string('subject')->nullable()->after('channel');
+            }
+            if (! Schema::hasColumn('contact_communications', 'provider')) {
+                $table->string('provider')->nullable()->after('subject');
+            }
+            if (! Schema::hasColumn('contact_communications', 'provider_message_id')) {
+                $table->string('provider_message_id')->nullable()->after('provider');
+            }
+            if (! Schema::hasColumn('contact_communications', 'status')) {
+                $table->string('status')->default('pending')->after('provider_message_id');
+            }
+            if (! Schema::hasColumn('contact_communications', 'delivered_at')) {
+                $table->timestamp('delivered_at')->nullable()->after('status');
+            }
+            if (! Schema::hasColumn('contact_communications', 'meta')) {
+                $table->json('meta')->nullable()->after('delivered_at');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('contact_communications')) {
+            return;
+        }
+
+        Schema::table('contact_communications', function (Blueprint $table) {
+            foreach (['channel', 'subject', 'provider', 'provider_message_id', 'status', 'delivered_at', 'meta'] as $column) {
+                if (Schema::hasColumn('contact_communications', $column)) {
+                    $table->dropColumn($column);
+                }
+            }
+        });
+    }
+};

--- a/database/migrations/2025_07_21_000001_create_property_media_table.php
+++ b/database/migrations/2025_07_21_000001_create_property_media_table.php
@@ -18,7 +18,11 @@ class CreatePropertyMediaTable extends Migration
             $table->foreignId('property_id')->constrained()->onDelete('cascade');
             $table->string('file_path');
             $table->string('type');
+            $table->string('disk')->default('public');
             $table->unsignedInteger('order')->default(0);
+            $table->string('caption')->nullable();
+            $table->boolean('is_primary')->default(false);
+            $table->json('conversions')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_07_21_100005_create_property_features_table.php
+++ b/database/migrations/2025_07_21_100005_create_property_features_table.php
@@ -7,8 +7,10 @@ return new class extends Migration {
         Schema::create('property_features', function (Blueprint $table) {
             $table->id();
             $table->foreignId('property_id')->constrained('properties')->onDelete('cascade');
+            $table->foreignId('feature_catalog_id')->nullable()->constrained('property_feature_catalogs')->nullOnDelete();
             $table->string('name');
             $table->string('value')->nullable();
+            $table->json('meta')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_07_22_000001_create_contact_communications_table.php
+++ b/database/migrations/2025_07_22_000001_create_contact_communications_table.php
@@ -11,6 +11,13 @@ return new class extends Migration {
             $table->foreignId('contact_id')->constrained()->onDelete('cascade');
             $table->foreignId('user_id')->nullable()->constrained()->onDelete('set null');
             $table->text('communication');
+            $table->string('channel')->default('internal');
+            $table->string('subject')->nullable();
+            $table->string('provider')->nullable();
+            $table->string('provider_message_id')->nullable();
+            $table->string('status')->default('pending');
+            $table->timestamp('delivered_at')->nullable();
+            $table->json('meta')->nullable();
             $table->timestamps();
         });
     }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,6 +15,8 @@ class DatabaseSeeder extends Seeder
             DemoDataSeeder::class, // Add demo data seeder
             CreateSuperAdminSeeder::class,
             TenantPortalUserSeeder::class,
+            PropertyFeatureCatalogSeeder::class,
+            PropertyChannelSeeder::class,
         ]);
     }
 }

--- a/database/seeders/PropertyChannelSeeder.php
+++ b/database/seeders/PropertyChannelSeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\PropertyChannel;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
+
+class PropertyChannelSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $channels = [
+            ['name' => 'Rightmove', 'slug' => 'rightmove', 'handler' => \App\Services\Portals\RightmovePortalPublisher::class],
+            ['name' => 'Zoopla', 'slug' => 'zoopla', 'handler' => \App\Services\Portals\ZooplaPortalPublisher::class],
+            ['name' => 'Company Website', 'slug' => 'website', 'handler' => null],
+        ];
+
+        foreach ($channels as $channel) {
+            PropertyChannel::updateOrCreate(
+                ['slug' => Str::slug($channel['slug'])],
+                ['name' => $channel['name'], 'handler' => $channel['handler']]
+            );
+        }
+    }
+}

--- a/database/seeders/PropertyFeatureCatalogSeeder.php
+++ b/database/seeders/PropertyFeatureCatalogSeeder.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\PropertyFeatureCatalog;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
+
+class PropertyFeatureCatalogSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $features = [
+            'Fully Furnished',
+            'River view',
+            'Shops and amenities nearby',
+            'Air Conditioning',
+            'Gym',
+            'Guest cloakroom',
+            'Mezzanine',
+            'Fitted Kitchen',
+            'Communal Garden',
+            'Roof Terrace',
+            'Balcony',
+            'Underground Parking',
+            'Driveway',
+            'Parking',
+            'En suite',
+            'Video Entry',
+            'Double glazing',
+            'Conservatory',
+            'Concierge',
+            'Close to public transport',
+            'Un-Furnished',
+            'Swimming Pool',
+            '24 hour on-site security',
+            'Receptionist',
+            'Meeting Room and Conference Facilities',
+        ];
+
+        foreach ($features as $feature) {
+            PropertyFeatureCatalog::firstOrCreate(
+                ['slug' => Str::slug($feature)],
+                ['name' => $feature, 'portal_key' => Str::upper(Str::slug($feature, '_'))]
+            );
+        }
+    }
+}

--- a/resources/views/emails/contact_communication.blade.php
+++ b/resources/views/emails/contact_communication.blade.php
@@ -1,0 +1,3 @@
+@component('mail::message')
+{!! nl2br(e($content)) !!}
+@endcomponent

--- a/resources/views/properties/create.blade.php
+++ b/resources/views/properties/create.blade.php
@@ -93,6 +93,12 @@
                         <div class="mb-3">
                             <label for="media" class="form-label">Media Gallery</label>
                             <input type="file" name="media[]" multiple class="form-control" accept="image/*">
+                            <small class="form-text text-muted">Upload additional images for the property gallery.</small>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Primary Media Index</label>
+                            <input type="number" name="primary_media" class="form-control" value="0" min="0">
+                            <small class="form-text text-muted">0 refers to the cover photo, 1 refers to the first gallery upload, and so on.</small>
                         </div>
                         <div class="mb-3">
                             <label for="features" class="form-label">Property Features</label>
@@ -100,8 +106,21 @@
                                 @foreach($featuresList as $feature)
                                     <div class="col-6 col-md-4">
                                         <div class="form-check">
-                                            <input class="form-check-input" type="checkbox" name="features[]" value="{{ $feature }}" id="feature_{{ md5($feature) }}">
-                                            <label class="form-check-label" for="feature_{{ md5($feature) }}">{{ $feature }}</label>
+                                            <input class="form-check-input" type="checkbox" name="features[]" value="{{ $feature->id }}" id="feature_{{ $feature->id }}">
+                                            <label class="form-check-label" for="feature_{{ $feature->id }}">{{ $feature->name }}</label>
+                                        </div>
+                                    </div>
+                                @endforeach
+                            </div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Syndication Channels</label>
+                            <div class="row">
+                                @foreach($channels as $channel)
+                                    <div class="col-6 col-md-4">
+                                        <div class="form-check">
+                                            <input class="form-check-input" type="checkbox" name="channels[]" value="{{ $channel->id }}" id="channel_{{ $channel->id }}">
+                                            <label class="form-check-label" for="channel_{{ $channel->id }}">{{ $channel->name }}</label>
                                         </div>
                                     </div>
                                 @endforeach

--- a/resources/views/properties/edit.blade.php
+++ b/resources/views/properties/edit.blade.php
@@ -151,7 +151,10 @@
                             @foreach($property->media as $media)
                                 <div class="col-4 col-md-3">
                                     <div class="card">
-                                        <img src="{{ asset('storage/' . $media->file_path) }}" class="card-img-top" alt="Media" style="height:120px;object-fit:cover;">
+                                        <img src="{{ Storage::disk($media->disk ?? 'public')->url($media->file_path) }}" class="card-img-top" alt="Media" style="height:120px;object-fit:cover;">
+                                        @if($media->is_primary)
+                                            <span class="badge bg-primary position-absolute m-2">Primary</span>
+                                        @endif
                                         <form action="{{ route('properties.media.destroy', [$property, $media]) }}" method="POST" onsubmit="return confirm('Delete this image?')">
                                             @csrf
                                             @method('DELETE')
@@ -164,6 +167,12 @@
                         <div class="mb-3">
                             <label for="media" class="form-label">Add Images</label>
                             <input type="file" name="media[]" multiple class="form-control" accept="image/*">
+                            <small class="form-text text-muted">Upload new images to append to the gallery.</small>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Primary Media Index</label>
+                            <input type="number" name="primary_media" class="form-control" value="0" min="0">
+                            <small class="form-text text-muted">0 refers to the cover photo, 1 to the first new upload.</small>
                         </div>
                         <div class="mb-3">
                             <label for="features" class="form-label">Property Features</label>
@@ -171,8 +180,21 @@
                                 @foreach($featuresList as $feature)
                                     <div class="col-6 col-md-4">
                                         <div class="form-check">
-                                            <input class="form-check-input" type="checkbox" name="features[]" value="{{ $feature }}" id="feature_{{ md5($feature) }}" @if(in_array($feature, $selectedFeatures)) checked @endif>
-                                            <label class="form-check-label" for="feature_{{ md5($feature) }}">{{ $feature }}</label>
+                                            <input class="form-check-input" type="checkbox" name="features[]" value="{{ $feature->id }}" id="feature_{{ $feature->id }}" @if(in_array($feature->id, $selectedFeatures)) checked @endif>
+                                            <label class="form-check-label" for="feature_{{ $feature->id }}">{{ $feature->name }}</label>
+                                        </div>
+                                    </div>
+                                @endforeach
+                            </div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Syndication Channels</label>
+                            <div class="row">
+                                @foreach($channels as $channel)
+                                    <div class="col-6 col-md-4">
+                                        <div class="form-check">
+                                            <input class="form-check-input" type="checkbox" name="channels[]" value="{{ $channel->id }}" id="channel_{{ $channel->id }}" @if(in_array($channel->id, $selectedChannels)) checked @endif>
+                                            <label class="form-check-label" for="channel_{{ $channel->id }}">{{ $channel->name }}</label>
                                         </div>
                                     </div>
                                 @endforeach

--- a/routes/web.php
+++ b/routes/web.php
@@ -70,6 +70,7 @@ Route::group(['middleware' => ['auth', 'verified', 'role:Admin|Landlord']], func
 // Tenant routes (aktonz.ressapp.com, etc.)
 Route::group(['middleware' => ['auth', 'tenancy', 'role:Tenant']], function () {
     Route::resource('properties', PropertyController::class);
+    Route::post('contacts/bulk', [ContactController::class, 'bulk'])->name('contacts.bulk');
     Route::resource('contacts', ContactController::class);
     Route::resource('diary', DiaryController::class);
     Route::resource('accounts', AccountController::class);

--- a/tests/Feature/PropertySyndicationTest.php
+++ b/tests/Feature/PropertySyndicationTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\SendContactCommunication;
+use App\Jobs\SyncPropertyToPortals;
+use App\Models\Contact;
+use App\Models\ContactTag;
+use App\Models\Property;
+use App\Models\PropertyChannel;
+use App\Models\PropertyFeatureCatalog;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class PropertySyndicationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutMiddleware();
+    }
+
+    public function test_property_creation_queues_portal_sync_with_channels(): void
+    {
+        $this->seed(\Database\Seeders\PropertyFeatureCatalogSeeder::class);
+
+        Bus::fake();
+        Storage::fake('public');
+        Http::fake([
+            'https://nominatim.openstreetmap.org/*' => Http::response([], 200),
+        ]);
+
+        $user = User::factory()->create(['is_admin' => true]);
+        $features = PropertyFeatureCatalog::take(2)->pluck('id')->toArray();
+        $rightmove = PropertyChannel::create([
+            'name' => 'Rightmove',
+            'slug' => 'rightmove',
+            'handler' => \App\Services\Portals\RightmovePortalPublisher::class,
+        ]);
+        $zoopla = PropertyChannel::create([
+            'name' => 'Zoopla',
+            'slug' => 'zoopla',
+            'handler' => \App\Services\Portals\ZooplaPortalPublisher::class,
+        ]);
+        $channels = [$rightmove->id, $zoopla->id];
+
+        $response = $this->actingAs($user)->post(route('properties.store'), [
+            'title' => 'Canalside Apartment',
+            'description' => 'Bright and spacious apartment with river views.',
+            'price' => 350000,
+            'address' => '123 River Road',
+            'city' => 'London',
+            'postcode' => 'E14 5AB',
+            'bedrooms' => 2,
+            'bathrooms' => 2,
+            'type' => 'Flat',
+            'status' => 'available',
+            'photo' => UploadedFile::fake()->image('cover.jpg'),
+            'features' => $features,
+            'channels' => $channels,
+            'publish_to_portal' => true,
+        ]);
+
+        $response->assertRedirect(route('properties.index'));
+
+        $property = Property::latest()->with(['features', 'channels'])->first();
+        $this->assertNotNull($property);
+        $this->assertEqualsCanonicalizing($features, $property->features->pluck('feature_catalog_id')->toArray());
+        $this->assertEqualsCanonicalizing($channels, $property->channels->pluck('id')->toArray());
+        // Debug: inspect queue pushes during test execution
+        Bus::assertDispatched(SyncPropertyToPortals::class, 1);
+    }
+
+    public function test_contact_communications_are_logged_via_providers(): void
+    {
+        $contact = Contact::factory()->create([
+            'email' => 'applicant@example.com',
+            'phone' => '+441234567890',
+        ]);
+
+        Mail::fake();
+        Http::fake([
+            '*' => Http::response(['sid' => 'SM12345'], 200),
+        ]);
+
+        SendContactCommunication::dispatchSync($contact, 'email', [
+            'subject' => 'Viewing Confirmation',
+            'body' => 'Your viewing is confirmed for tomorrow.',
+        ], null);
+
+        SendContactCommunication::dispatchSync($contact, 'sms', [
+            'body' => 'Reminder: viewing tomorrow at 10am.',
+        ], null);
+
+        $communications = $contact->communications()->orderBy('created_at')->get();
+        $this->assertCount(2, $communications);
+        $this->assertEquals('email', $communications->first()->channel);
+        $this->assertEquals('delivered', $communications->first()->status);
+        $this->assertEquals('sms', $communications->last()->channel);
+        $this->assertEquals('delivered', $communications->last()->status);
+        $this->assertEquals('twilio', $communications->last()->provider);
+    }
+
+    public function test_bulk_segment_dispatches_jobs_for_tagged_contacts(): void
+    {
+        $this->seed(\Database\Seeders\PropertyFeatureCatalogSeeder::class);
+        $tag = ContactTag::create(['name' => 'Investors']);
+        Contact::factory()->count(2)->create()->each(function ($contact) use ($tag) {
+            $contact->tags()->attach($tag->id);
+        });
+
+        Bus::fake();
+        Http::fake([
+            'https://nominatim.openstreetmap.org/*' => Http::response([], 200),
+        ]);
+
+        $user = User::factory()->create(['is_admin' => true]);
+
+        $response = $this->actingAs($user)->post(route('contacts.bulk'), [
+            'action' => 'email',
+            'contacts' => [],
+            'segment_tags' => [$tag->id],
+            'subject' => 'New property launch',
+            'body' => 'Check out our new listings.',
+        ]);
+
+        $response->assertRedirect();
+        Bus::assertDispatched(SendContactCommunication::class, 2);
+    }
+}


### PR DESCRIPTION
## Summary
- replace static property feature and media handling with catalog-backed selections, gallery management, and channel-aware portal sync orchestration
- introduce reusable portal publisher and messaging channel services with queued jobs for email/SMS delivery and richer contact communication logging
- add database seeders, configuration, routes, and feature coverage to exercise property syndication, marketing segmentation, and provider integrations

## Testing
- php artisan test --filter=PropertySyndicationTest

------
https://chatgpt.com/codex/tasks/task_e_68e1b2e3c55c832e9d23b21159707048