### PR TITLE
Fix fallback host declarations in tenant login view

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
     "private": true,
+    "type": "module",
     "scripts": {
         "prod": "npm run build",
         "dev": "vite",

--- a/resources/js/marketing/views/TenantLoginView.vue
+++ b/resources/js/marketing/views/TenantLoginView.vue
@@ -56,7 +56,19 @@ const analytics = inject('analytics');
 const sessionId = inject('marketingSession');
 
 const loginHost = 'aktonz.darkorange-chinchilla-918430.hostingersite.com';
-const fallbackHost = 'app.ressapp.com';
+const defaultFallbackHost = 'app.ressapp.com';
+
+const tenantFallbackHost =
+    typeof window !== 'undefined' && window.tenantFallbackHost
+        ? window.tenantFallbackHost
+        : defaultFallbackHost;
+
+const globalFallbackHost =
+    typeof window !== 'undefined' && window.globalFallbackHost
+        ? window.globalFallbackHost
+        : defaultFallbackHost;
+
+const fallbackHost = tenantFallbackHost;
 
 const loginLinks = [
     {
@@ -67,19 +79,17 @@ const loginLinks = [
     },
     {
         id: 'fallback',
-        label: `Open backup login (${fallbackHost})`,
+        label: `Open backup login (${tenantFallbackHost})`,
         className: 'tenant-login__alt',
         href: `https://${tenantFallbackHost}/login`,
     },
     {
         id: 'global-fallback',
-        label: 'Open backup login (app.ressapp.com)',
+        label: `Open backup login (${globalFallbackHost})`,
         className: 'tenant-login__alt',
         href: `https://${globalFallbackHost}/login`,
     },
 ];
-
-const fallbackHost = globalFallbackHost;
 
 function trackLogin(target) {
     analytics?.track(


### PR DESCRIPTION
## Summary
- resolve the duplicate `fallbackHost` declaration in the Aktonz tenant login view by deriving tenant and global fallback hosts safely
- fall back to sensible defaults when the host globals are absent and surface the resolved values in link labels
- mark the package as an ES module to suppress the npm warning about reparsing

## Testing
- npm run build *(fails in this environment: missing @vitejs/plugin-vue)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b9a32918832eba8ff9d67c33a1d7