### PR TITLE
Fix fallbackHost redeclaration in tenant login view

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
     "private": true,
+    "type": "module",
     "scripts": {
         "prod": "npm run build",
         "dev": "vite",

--- a/resources/js/marketing/views/TenantLoginView.vue
+++ b/resources/js/marketing/views/TenantLoginView.vue
@@ -56,7 +56,10 @@ const analytics = inject('analytics');
 const sessionId = inject('marketingSession');
 
 const loginHost = 'aktonz.darkorange-chinchilla-918430.hostingersite.com';
-const fallbackHost = 'app.ressapp.com';
+const fallbackHost =
+    typeof globalThis !== 'undefined' && typeof globalThis.globalFallbackHost === 'string'
+        ? globalThis.globalFallbackHost
+        : 'app.ressapp.com';
 
 const loginLinks = [
     {
@@ -78,8 +81,6 @@ const loginLinks = [
         href: `https://${globalFallbackHost}/login`,
     },
 ];
-
-const fallbackHost = globalFallbackHost;
 
 function trackLogin(target) {
     analytics?.track(


### PR DESCRIPTION
## Summary
- avoid redeclaring the fallbackHost constant by preferring a global override when available
- mark the frontend workspace as an ES module to silence the npm warning about reparsing

## Testing
- npm run build:marketing *(fails: missing @vitejs/plugin-vue in node_modules within the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b9e8aaac832e83f8386814af8386