### PR TITLE
Sanitize tenant fallback host detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
     "private": true,
+    "type": "module",
     "scripts": {
         "prod": "npm run build",
         "dev": "vite",

--- a/resources/js/marketing/views/TenantLoginView.vue
+++ b/resources/js/marketing/views/TenantLoginView.vue
@@ -56,7 +56,28 @@ const analytics = inject('analytics');
 const sessionId = inject('marketingSession');
 
 const loginHost = 'aktonz.darkorange-chinchilla-918430.hostingersite.com';
-const fallbackHost = 'app.ressapp.com';
+const defaultFallbackHost = 'app.ressapp.com';
+
+function readHostFromWindow(key) {
+    if (typeof window === 'undefined') {
+        return undefined;
+    }
+
+    const value = window[key];
+
+    if (typeof value !== 'string') {
+        return undefined;
+    }
+
+    const trimmed = value.trim();
+
+    return trimmed.length ? trimmed : undefined;
+}
+
+const tenantFallbackHost = readHostFromWindow('tenantFallbackHost') ?? defaultFallbackHost;
+const globalFallbackHost = readHostFromWindow('globalFallbackHost') ?? defaultFallbackHost;
+
+const fallbackHost = tenantFallbackHost || globalFallbackHost;
 
 const loginLinks = [
     {
@@ -67,19 +88,17 @@ const loginLinks = [
     },
     {
         id: 'fallback',
-        label: `Open backup login (${fallbackHost})`,
+        label: `Open backup login (${tenantFallbackHost})`,
         className: 'tenant-login__alt',
         href: `https://${tenantFallbackHost}/login`,
     },
     {
         id: 'global-fallback',
-        label: 'Open backup login (app.ressapp.com)',
+        label: `Open backup login (${globalFallbackHost})`,
         className: 'tenant-login__alt',
         href: `https://${globalFallbackHost}/login`,
     },
 ];
-
-const fallbackHost = globalFallbackHost;
 
 function trackLogin(target) {
     analytics?.track(


### PR DESCRIPTION
## Summary
- guard fallback host reads behind a helper that normalizes window-provided values
- default tenant and global fallback hosts to sensible values when the browser globals are missing or empty

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1b9a32918832eba8ff9d67c33a1d7