### PR TITLE
Add test ensuring Aktonz tenant Hostinger domain is seeded

### DIFF
--- a/tests/Feature/TenantFixturesTest.php
+++ b/tests/Feature/TenantFixturesTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Feature;
+
+use Database\Seeders\TenantFixtures;
+use Stancl\Tenancy\Database\Models\Domain;
+use Tests\TestCase;
+
+class TenantFixturesTest extends TestCase
+{
+    /** @test */
+    public function it_seeds_the_aktonz_hostinger_domain(): void
+    {
+        TenantFixtures::seed();
+
+        $this->assertTrue(
+            Domain::query()
+                ->where('domain', 'aktonz.darkorange-chinchilla-918430.hostingersite.com')
+                ->exists(),
+            'Aktonz Hostinger domain was not seeded.'
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a feature test to confirm TenantFixtures seeds the Aktonz Hostinger domain

## Testing
- ./vendor/bin/phpunit --filter TenantFixturesTest

------
https://chatgpt.com/codex/tasks/task_e_68e1bcdd1550832e993dc9bd75ce6093