### PR TITLE
Document main branch usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 This repository contains a Laravel application.
 
+## Branching model
+
+The canonical integration branch is `main`. The historic `master` branch is no
+longer used in this repository, so you will not see it locally after cloning.
+When the hosting instructions or older automation scripts mention `master`,
+substitute `main` instead (for example, `git checkout main` or `git pull origin
+main`). Keeping your local clone on the `main` branch ensures you receive the
+latest code that powers production deployments.
+
 ## Running Artisan Commands
 
 All Artisan commands must be executed from the project root where the `artisan` file lives.

--- a/deploy_hostinger.sh
+++ b/deploy_hostinger.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Laravel deployment script for Hostinger (master branch)
+# Laravel deployment script for Hostinger (main branch)
 
 # Exit on error
 set -euo pipefail


### PR DESCRIPTION
## Summary
- add a README section that explains `main` is the canonical branch and that `master` is no longer used
- update the Hostinger deployment script comment to reference the main branch so the documentation matches reality

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e1d0b92998832e89abdede69967df2