### PR TITLE
Harden Hostinger rewrite guard

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,14 @@
+RewriteEngine On
+
+# Skip rewrites for requests that are already pointing at the Laravel public directory.
+RewriteCond %{REQUEST_URI} ^/public/
+RewriteRule ^ - [L]
+
+# Allow existing files or directories at the document root to pass through untouched.
+RewriteCond %{REQUEST_FILENAME} -f [OR]
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^ - [L]
+
+# Otherwise send everything into the Laravel public directory.
+RewriteCond %{REQUEST_URI} !^/public/
+RewriteRule ^(.*)$ public/$1 [L]


### PR DESCRIPTION
## Summary
- add a request-URI guard so rewrite rules skip paths that already target the public directory
- keep existing root files and directories passthrough before routing traffic into Laravel's public folder

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e1c3c8eb78832ea2c82e078c5bbc58