### PR TITLE
Add workflow to sync master branch with main

### DIFF
--- a/.github/workflows/sync-master.yml
+++ b/.github/workflows/sync-master.yml
@@ -1,0 +1,24 @@
+name: Sync master branch
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync-master:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update master to match main
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git push --force-with-lease origin HEAD:master


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that syncs the master branch with the main branch after each push

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68e46824d2c4832e987ae6bd4246b0b2